### PR TITLE
feat: add context health pill, command palette, code-block UX, and token tracking

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -123,9 +123,26 @@
           </svg>
         </div>
       </div>
+      <!-- Context health pill — updated by ui/ctx-pill.js after each turn -->
+      <span
+        id="ctx-pill"
+        title="Context usage — click for details"
+        class="ctx-pill ctx-ok"
+        aria-live="polite"
+        aria-label="Context window usage">
+        0%
+      </span>
     </div>
 
     <div class="flex items-center gap-2 flex-shrink-0">
+      <!-- Command palette trigger — click or Ctrl+K -->
+      <button
+        id="palette-trigger-btn"
+        title="Command palette (Ctrl+K)"
+        aria-label="Open command palette"
+        class="nav-icon-btn palette-trigger">
+        ⌘
+      </button>
       <button id="settings-btn" title="Settings" class="p-2 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
@@ -158,6 +175,10 @@
         <button class="suggestion text-xs px-3 py-1.5 rounded-full border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 transition-colors">Help me brainstorm ideas</button>
         <button class="suggestion text-xs px-3 py-1.5 rounded-full border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 transition-colors">Debug my code</button>
       </div>
+      <!-- Ghost-text discoverability hint — intentionally muted -->
+      <p class="empty-hint" aria-hidden="true">
+        Press <kbd>Ctrl+K</kbd> for commands
+      </p>
     </div>
 
     <!-- Messages container -->
@@ -232,6 +253,23 @@
       </button>
     </div>
   </div>
+</div>
+
+
+<!-- Command Palette — visibility controlled by features/palette.js via .hidden class -->
+<div id="cmd-palette" class="hidden" role="dialog" aria-modal="true" aria-label="Command palette">
+  <div id="cmd-palette-inner">
+    <input
+      id="cmd-search"
+      type="text"
+      placeholder="Type a command…"
+      autocomplete="off"
+      spellcheck="false"
+      aria-label="Search commands"
+    />
+    <ul id="cmd-list" role="listbox" aria-label="Available commands"></ul>
+  </div>
+  <div id="cmd-backdrop"></div>
 </div>
 
 <script type="module" src="src/app.js"></script>

--- a/freeforge/src/api.js
+++ b/freeforge/src/api.js
@@ -1,4 +1,3 @@
-import { S } from './state.js';
 import { showInvalidBanner } from './ui/screen.js';
 
 export async function fetchFreeModels(key) {
@@ -18,10 +17,7 @@ export async function fetchFreeModels(key) {
   }).sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id));
 }
 
-export async function streamCompletion(msgs, modelId, key, { onToken, onDone, onError }) {
-  const ctrl = new AbortController();
-  S.abort = ctrl;
-
+export async function streamCompletion(msgs, modelId, key, { onToken, onDone, onError, signal }) {
   let res;
   try {
     res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
@@ -31,10 +27,10 @@ export async function streamCompletion(msgs, modelId, key, { onToken, onDone, on
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ model: modelId, messages: msgs, stream: true }),
-      signal: ctrl.signal,
+      signal,
     });
   } catch (e) {
-    if (e.name === 'AbortError') { onDone(''); return; }
+    if (e.name === 'AbortError') return onDone('{}', '');
     onError('Network error — check your connection.');
     return;
   }
@@ -52,7 +48,7 @@ export async function streamCompletion(msgs, modelId, key, { onToken, onDone, on
 
   const reader = res.body.getReader();
   const dec = new TextDecoder();
-  let buf = '', full = '';
+  let buf = '', full = '', donePayload = '{}';
 
   try {
     while (true) {
@@ -68,14 +64,17 @@ export async function streamCompletion(msgs, modelId, key, { onToken, onDone, on
         if (raw === '[DONE]') continue;
         try {
           const j = JSON.parse(raw);
+          if (j?.usage?.total_tokens !== undefined) donePayload = raw;
           const delta = j.choices?.[0]?.delta?.content;
           if (delta) { full += delta; onToken(delta, full); }
         } catch {}
       }
     }
   } catch (e) {
-    if (e.name !== 'AbortError') onError('Stream interrupted.');
+    if (e.name === 'AbortError') return onDone(donePayload, full);
+    onError('Stream interrupted.');
     return;
   }
-  onDone(full);
+  return onDone(donePayload, full);
 }
+

--- a/freeforge/src/app.js
+++ b/freeforge/src/app.js
@@ -6,6 +6,8 @@ import { loadModels } from './features/models.js';
 import { validateAndConnect, hideObError } from './features/onboarding.js';
 import { openSettings, closeSettings, updateKey, clearKey } from './features/settings.js';
 import { sendMessage, regenerate, newChat } from './features/chat.js';
+import { renderCtxPill } from './ui/ctx-pill.js';
+import { openPalette, closePalette } from './features/palette.js';
 
 async function init() {
   const savedKey = getStoredKey();
@@ -21,6 +23,7 @@ async function init() {
   renderAllMessages();
   scrollBottom(false);
   await loadModels(savedKey);
+  renderCtxPill();
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -42,6 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const prev = S.selectedModel;
     S.selectedModel = e.target.value;
     LS.set('ff_model', S.selectedModel);
+    renderCtxPill();
     if (prev && prev !== S.selectedModel) {
       const m = S.models.find(x => x.id === S.selectedModel);
       toast(`Model: ${m?.name || S.selectedModel.split('/').pop()}`, 'info');
@@ -100,6 +104,24 @@ document.addEventListener('DOMContentLoaded', () => {
   // regenerate — delegated to avoid circular dep between messages.js and chat.js
   document.addEventListener('click', e => {
     if (e.target.closest('.regen-btn')) regenerate();
+  });
+
+  // command palette
+  document.addEventListener('keydown', e => {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+      const active = document.activeElement;
+      const isInInput = active instanceof HTMLInputElement
+        || active instanceof HTMLTextAreaElement;
+      const paletteOpen = !document.getElementById('cmd-palette')?.classList.contains('hidden');
+      if (!isInInput || paletteOpen) {
+        e.preventDefault();
+        paletteOpen ? closePalette() : openPalette();
+      }
+    }
+
+    if (e.key === 'Escape' && S.streaming) {
+      S.abort?.abort();
+    }
   });
 
   // escape closes modal

--- a/freeforge/src/features/chat.js
+++ b/freeforge/src/features/chat.js
@@ -1,6 +1,7 @@
 import { S, $, LS, uid } from '../state.js';
 import { streamCompletion } from '../api.js';
 import { toast } from '../ui/toast.js';
+import { renderCtxPill } from '../ui/ctx-pill.js';
 import { renderAllMessages, scrollBottom, setStreamMode } from '../ui/messages.js';
 
 export async function sendMessage(text) {
@@ -9,6 +10,7 @@ export async function sendMessage(text) {
   if (!S.selectedModel) { toast('Select a model first', 'warning'); return; }
 
   const isFirst = S.messages.filter(m => m.role === 'user').length === 0;
+  S.lastAssistantResponse = '';
 
   S.messages.push({ id: uid(), role: 'user', content: text });
 
@@ -30,9 +32,12 @@ export async function sendMessage(text) {
     .map(m => ({ role: m.role, content: m.content }));
 
   let firstToken = true;
+  const ctrl = new AbortController();
+  S.abort = ctrl;
   S.streamTarget = null;
 
   await streamCompletion(payload, S.selectedModel, S.apiKey, {
+    signal: ctrl.signal,
     onToken(_delta, full) {
       if (firstToken) {
         firstToken = false;
@@ -40,12 +45,27 @@ export async function sendMessage(text) {
         S.streamTarget = document.querySelector(`[data-id="${asstId}"] .msg-content`);
       }
       asstMsg.content = full;
+      S.lastAssistantResponse = full;
       if (S.streamTarget) S.streamTarget.textContent = full;
       scrollBottom(false);
     },
-    onDone(full) {
+    onDone(rawPayload, full) {
+      let parsed;
+      try { parsed = JSON.parse(rawPayload); } catch { parsed = {}; }
+      const exactTokens = parsed?.usage?.total_tokens ?? null;
+      if (exactTokens !== null) {
+        S.contextTokens += exactTokens;
+        S.usageIsExact = true;
+      } else {
+        const charEstimate = Math.ceil((text.length + S.lastAssistantResponse.length) / 4);
+        S.contextTokens += charEstimate;
+        S.usageIsExact = false;
+      }
+      if (!Number.isFinite(S.contextTokens) || S.contextTokens < 0) S.contextTokens = 0;
+
       $('thinking').classList.add('hidden');
       asstMsg.content = full || asstMsg.content;
+      S.lastAssistantResponse = asstMsg.content;
       asstMsg.streaming = false;
       S.streaming = false;
       S.abort = null;
@@ -53,7 +73,9 @@ export async function sendMessage(text) {
       setStreamMode(false);
       LS.set('ff_msgs', S.messages);
       renderAllMessages();
+      renderCtxPill();
       scrollBottom();
+      return exactTokens;
     },
     onError(errMsg) {
       $('thinking').classList.add('hidden');
@@ -84,12 +106,27 @@ export async function regenerate() {
   await sendMessage(text);
 }
 
+export function copyLastResponse() {
+  const msg = [...S.messages].reverse().find(m => m.role === 'assistant' && m.content);
+  if (!msg) { toast('No response to copy yet', 'info'); return; }
+  navigator.clipboard.writeText(msg.content)
+    .then(() => toast('Copied', 'success'))
+    .catch(() => toast('Copy failed — clipboard blocked on file://', 'error'));
+}
+
 export function newChat() {
   if (S.abort) { S.abort.abort(); S.abort = null; }
   S.messages = [];
   S.streaming = false;
+  S.contextTokens = 0;
+  S.usageIsExact = false;
+  S.ctxToastFired = false;
+  S.lastAssistantResponse = '';
   setStreamMode(false);
   $('thinking').classList.add('hidden');
   LS.set('ff_msgs', []);
   renderAllMessages();
+  renderCtxPill();
 }
+
+if (typeof window !== 'undefined') window.newChat = newChat;

--- a/freeforge/src/features/export.js
+++ b/freeforge/src/features/export.js
@@ -1,0 +1,18 @@
+import { S } from '../state.js';
+import { toast } from '../ui/toast.js';
+
+export function exportConversation() {
+  if (!S.messages.length) { toast('No conversation to export yet', 'info'); return; }
+  const text = S.messages
+    .filter(m => m.role === 'user' || m.role === 'assistant')
+    .map(m => `## ${m.role}\n\n${m.content}`)
+    .join('\n\n---\n\n');
+  const blob = new Blob([text], { type: 'text/markdown' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `freeforge-chat-${new Date().toISOString().slice(0, 10)}.md`;
+  a.click();
+  URL.revokeObjectURL(url);
+  toast('Conversation exported', 'success');
+}

--- a/freeforge/src/features/models.js
+++ b/freeforge/src/features/models.js
@@ -57,3 +57,13 @@ export function populateModelsFromState() {
   if (validSaved) { sel.value = saved; S.selectedModel = saved; }
   else if (S.models[0]) { sel.value = S.models[0].id; S.selectedModel = S.models[0].id; }
 }
+
+export function changeModel(modelId) {
+  if (!modelId) return;
+  const exists = S.models.find(m => m.id === modelId);
+  if (!exists) { toast('Model unavailable', 'warning'); return; }
+  S.selectedModel = modelId;
+  $('model-select').value = modelId;
+  LS.set('ff_model', modelId);
+  toast(`Model: ${exists.name || modelId.split('/').pop()}`, 'info');
+}

--- a/freeforge/src/features/palette.js
+++ b/freeforge/src/features/palette.js
@@ -1,0 +1,87 @@
+import { S } from '../state.js';
+import { newChat, copyLastResponse } from './chat.js';
+import { changeModel } from './models.js';
+import { openSettings } from './settings.js';
+import { exportConversation } from './export.js';
+
+const BASE_ACTIONS = [
+  { label: 'New Chat', shortcut: 'N', action: () => { newChat(); closePalette(); } },
+  { label: 'Copy Last Response', shortcut: 'C', action: () => { copyLastResponse(); closePalette(); } },
+  { label: 'Export Conversation', shortcut: 'E', action: () => { exportConversation(); closePalette(); } },
+  { label: 'Settings', shortcut: ',', action: () => { openSettings(); closePalette(); } },
+];
+
+let activeIndex = 0;
+let filteredActions = [];
+
+function buildActions() {
+  const modelActions = (S.models ?? []).map(m => ({
+    label: `Switch Model → ${m.name ?? m.id}`,
+    shortcut: '',
+    action: () => { changeModel(m.id); closePalette(); },
+  }));
+  return [...BASE_ACTIONS, ...modelActions];
+}
+
+function render(query = '') {
+  filteredActions = buildActions().filter(a =>
+    a.label.toLowerCase().includes(query.toLowerCase())
+  );
+  activeIndex = Math.min(activeIndex, Math.max(filteredActions.length - 1, 0));
+  const list = document.getElementById('cmd-list');
+  if (!list) return;
+  list.innerHTML = '';
+  filteredActions.forEach((a, i) => {
+    const li = document.createElement('li');
+    li.role = 'option';
+    li.className = i === activeIndex ? 'cmd-item cmd-active' : 'cmd-item';
+    li.textContent = a.label;
+    if (a.shortcut) {
+      const kb = document.createElement('kbd');
+      kb.textContent = a.shortcut;
+      li.appendChild(kb);
+    }
+    li.addEventListener('click', () => a.action());
+    list.appendChild(li);
+  });
+}
+
+export function openPalette() {
+  activeIndex = 0;
+  const palette = document.getElementById('cmd-palette');
+  const input = document.getElementById('cmd-search');
+  if (!palette || !input) return;
+  palette.classList.remove('hidden');
+  input.value = '';
+  render('');
+  input.focus();
+}
+
+export function closePalette() {
+  document.getElementById('cmd-palette')?.classList.add('hidden');
+}
+
+document.getElementById('cmd-search')?.addEventListener('input', e => {
+  activeIndex = 0;
+  render(e.target.value);
+});
+
+document.getElementById('cmd-palette')?.addEventListener('keydown', e => {
+  if (e.key === 'Escape') { closePalette(); return; }
+  if (e.key === 'ArrowDown') {
+    activeIndex = Math.min(activeIndex + 1, Math.max(filteredActions.length - 1, 0));
+    render(document.getElementById('cmd-search')?.value ?? '');
+    e.preventDefault();
+  }
+  if (e.key === 'ArrowUp') {
+    activeIndex = Math.max(activeIndex - 1, 0);
+    render(document.getElementById('cmd-search')?.value ?? '');
+    e.preventDefault();
+  }
+  if (e.key === 'Enter' && filteredActions[activeIndex]) {
+    filteredActions[activeIndex].action();
+  }
+});
+
+document.getElementById('cmd-backdrop')?.addEventListener('click', closePalette);
+document.getElementById('palette-trigger-btn')?.addEventListener('click', openPalette);

--- a/freeforge/src/markdown.js
+++ b/freeforge/src/markdown.js
@@ -16,10 +16,18 @@ const PURIFY_CONFIG = {
     'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
     'a', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'hr',
   ],
-  ALLOWED_ATTR: ['href', 'title'],
+  ALLOWED_ATTR: ['href', 'title', 'class'],
   FORBID_ATTR: ['style', 'onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur'],
   FORCE_BODY: true,
 };
+
+if (typeof DOMPurify !== 'undefined') {
+  DOMPurify.addHook('uponSanitizeAttribute', (node, data) => {
+    if (data.attrName !== 'class') return;
+    const isLanguageClass = /^language-[a-z0-9_-]+$/i.test(data.attrValue);
+    if (node.nodeName !== 'CODE' || !isLanguageClass) data.keepAttr = false;
+  });
+}
 
 export function renderMd(text) {
   if (!text) return '';

--- a/freeforge/src/state.js
+++ b/freeforge/src/state.js
@@ -15,6 +15,10 @@ export const S = {
   streaming: false,
   abort: null,
   streamTarget: null,
+  contextTokens: 0,
+  usageIsExact: false,
+  ctxToastFired: false,
+  lastAssistantResponse: '',
 };
 
 export const LS = {

--- a/freeforge/src/ui/ctx-pill.js
+++ b/freeforge/src/ui/ctx-pill.js
@@ -1,0 +1,31 @@
+import { S } from '../state.js';
+import { toast } from './toast.js';
+
+export function renderCtxPill() {
+  const pill = document.getElementById('ctx-pill');
+  if (!pill) return;
+  const model = S.models.find(m => m.id === S.selectedModel) ?? {};
+  const ceiling = model.context_length ?? 8192;
+  const pct = Math.min(Math.round((S.contextTokens / ceiling) * 100), 100);
+  const isEst = !S.usageIsExact;
+  const prefix = isEst ? '~' : '';
+
+  pill.textContent = `${prefix}${pct}%`;
+  pill.title = isEst
+    ? `~${S.contextTokens.toLocaleString()} tokens estimated (char÷4) of ${ceiling.toLocaleString()} — exact usage depends on model tokenizer`
+    : `${S.contextTokens.toLocaleString()} tokens used of ${ceiling.toLocaleString()}`;
+  pill.classList.remove('ctx-ok', 'ctx-warn', 'ctx-danger', 'ctx-est');
+  if (pct >= 90) pill.classList.add('ctx-danger');
+  else if (pct >= 75) pill.classList.add('ctx-warn');
+  else pill.classList.add('ctx-ok');
+  if (isEst) pill.classList.add('ctx-est');
+
+  if (pct >= 90 && !S.ctxToastFired) {
+    S.ctxToastFired = true;
+    toast(
+      'Context nearly full — <button onclick="newChat()" class="toast-action-btn">New Chat</button>',
+      'warning',
+      0
+    );
+  }
+}

--- a/freeforge/src/ui/messages.js
+++ b/freeforge/src/ui/messages.js
@@ -2,6 +2,32 @@ import { S, $, esc } from '../state.js';
 import { renderMd } from '../markdown.js';
 import { toast } from './toast.js';
 
+
+function injectCodeBlockUI(container) {
+  container.querySelectorAll('pre').forEach(pre => {
+    const codeEl = pre.querySelector('code');
+    if (!codeEl || pre.querySelector('.copy-code-btn')) return;
+    const langClass = [...codeEl.classList].find(c => c.startsWith('language-'));
+    const lang = langClass ? langClass.replace('language-', '') : '';
+
+    if (lang) {
+      const label = document.createElement('span');
+      label.className = 'lang-label';
+      label.textContent = lang;
+      pre.appendChild(label);
+    }
+    const btn = document.createElement('button');
+    btn.className = 'copy-code-btn';
+    btn.textContent = 'Copy';
+    btn.addEventListener('click', () => {
+      navigator.clipboard.writeText(codeEl.textContent)
+        .then(() => toast('Copied', 'success'))
+        .catch(() => toast('Copy failed — clipboard blocked on file://', 'error'));
+    });
+    pre.appendChild(btn);
+  });
+}
+
 export function scrollBottom(smooth = true) {
   const a = $('msgs-area');
   a.scrollTo({ top: a.scrollHeight, behavior: smooth ? 'smooth' : 'instant' });
@@ -87,6 +113,8 @@ export function buildMsgEl(msg, showRegen = false) {
         </div>
       </div>
     </div>`;
+
+  if (!msg.streaming) injectCodeBlockUI(wrap);
 
   const copyBtn = wrap.querySelector('.copy-btn');
   if (copyBtn) {

--- a/freeforge/src/ui/toast.js
+++ b/freeforge/src/ui/toast.js
@@ -23,7 +23,10 @@ export function toast(msg, type = 'info', ms = 3000) {
   const el = document.createElement('div');
   el.className = `toast pointer-events-auto flex items-start gap-2.5 px-3.5 py-3 rounded-xl border text-sm shadow-xl ${PALETTE[type]}`;
   el.style.cssText = `background:${BG[type]};max-width:320px;word-break:break-word`;
-  el.innerHTML = `<svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="${ICONS[type]}"/></svg><span>${esc(msg)}</span>`;
+  if (ms === 0) el.style.animation = 'toastIn .25s ease-out';
+  const safeAction = '<button onclick="newChat()" class="toast-action-btn">New Chat</button>';
+  const body = msg.includes(safeAction) ? esc(msg).replace(esc(safeAction), safeAction) : esc(msg);
+  el.innerHTML = `<svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="${ICONS[type]}"/></svg><span>${body}</span>`;
   $('toasts').appendChild(el);
-  setTimeout(() => el.remove(), ms + 300);
+  if (ms > 0) setTimeout(() => el.remove(), ms + 300);
 }

--- a/freeforge/styles/app.css
+++ b/freeforge/styles/app.css
@@ -49,3 +49,164 @@ body{background:#09090b;color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFo
 .modal-bg{background:rgba(0,0,0,.7);backdrop-filter:blur(4px)}
 .modal-card{animation:slideUp .2s ease-out}
 select{-webkit-appearance:none;appearance:none}
+
+/* ── Context health pill (BLU-05) ───────────────────────────────────── */
+.ctx-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: default;
+  transition: background 0.4s, color 0.4s;
+  user-select: none;
+}
+.ctx-ok { background: #14532d22; color: #4ade80; }
+.ctx-warn { background: #78350f22; color: #fb923c; }
+.ctx-danger { background: #7f1d1d22; color: #f87171; }
+.ctx-est { opacity: 0.75; }
+
+/* ── Code block affordances (BLU-10) ───────────────────────────────── */
+pre {
+  position: relative;
+}
+pre:has(.copy-code-btn) {
+  padding-top: 2rem;
+}
+.lang-label {
+  position: absolute;
+  top: 0.35rem;
+  left: 0.75rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #64748b;
+  pointer-events: none;
+  user-select: none;
+}
+.copy-code-btn {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.5rem;
+  padding: 2px 8px;
+  font-size: 0.65rem;
+  border-radius: 4px;
+  border: 1px solid #334155;
+  background: #1e293b;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.copy-code-btn:hover {
+  background: #334155;
+  color: #e2e8f0;
+}
+
+.toast-action-btn {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: none;
+  padding: 0;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+/* ── Command palette trigger button (BLU-12) ───────────────────────── */
+.palette-trigger {
+  font-size: 1rem;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  color: #52525b;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+.palette-trigger:hover { color: #a1a1aa; background: #27272a; }
+
+/* ── Empty state Ctrl+K hint (BLU-13) ──────────────────────────────── */
+.empty-hint {
+  font-size: 0.65rem;
+  color: #3f3f46;
+  text-align: center;
+  margin-top: 1.5rem;
+  user-select: none;
+}
+.empty-hint kbd {
+  font-family: inherit;
+  background: #27272a;
+  border: 1px solid #3f3f46;
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-size: 0.6rem;
+}
+
+/* ── Command Palette (BLU-14) ───────────────────────────────────────── */
+#cmd-palette {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 20vh;
+}
+#cmd-palette.hidden { display: none; }
+#cmd-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+}
+#cmd-palette-inner {
+  position: relative;
+  z-index: 1;
+  width: min(480px, 90vw);
+  background: #18181b;
+  border: 1px solid #3f3f46;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 24px 48px rgba(0,0,0,0.6);
+}
+#cmd-search {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #27272a;
+  color: #e4e4e7;
+  font-size: 0.9rem;
+  outline: none;
+  box-sizing: border-box;
+}
+#cmd-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.cmd-item {
+  padding: 0.5rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #a1a1aa;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.cmd-item:hover, .cmd-active { background: #27272a; color: #e4e4e7; }
+.cmd-item kbd {
+  font-size: 0.65rem;
+  background: #3f3f46;
+  border-radius: 3px;
+  padding: 1px 5px;
+  color: #71717a;
+}


### PR DESCRIPTION
### Motivation
- Surface context usage to the user and warn when the conversation nears the model limit. 
- Improve developer and user productivity with a command palette and export action. 
- Improve assistant response UX for code (language labels + copy) while keeping markdown sanitization safe. 
- Make streaming usage parsing stateless so token usage can be accumulated and presented without coupling to API internals.

### Description
- Added context bookkeeping to `freeforge/src/state.js` (`contextTokens`, `usageIsExact`, `ctxToastFired`, `lastAssistantResponse`) and a renderer `freeforge/src/ui/ctx-pill.js` with a UI pill inserted in `freeforge/index.html`. 
- Made `streamCompletion` in `freeforge/src/api.js` stateless and return the final usage payload; `freeforge/src/features/chat.js` now wires an `AbortController`, tracks `lastAssistantResponse`, accumulates exact or estimated token counts per turn, updates the context pill via `renderCtxPill()`, and exposes `newChat()` globally. 
- Added a command palette shell in `freeforge/index.html` and `freeforge/src/features/palette.js` with Ctrl/Cmd+K wiring in `freeforge/src/app.js` plus a small action list that includes model switching, new chat, copy last response, export, and settings. 
- Added conversation export helper `freeforge/src/features/export.js`. 
- Improved code-block UX: `freeforge/src/ui/messages.js` now injects language labels and a copy button into rendered `pre/code` blocks, and `freeforge/src/markdown.js` allows only safe `class` attributes for `language-*` on `code` nodes via a DOMPurify hook. 
- Adjusted toasts in `freeforge/src/ui/toast.js` to safely render a persistent inline action (New Chat CTA) and avoid auto-dismiss when `ms === 0`, and added styles in `freeforge/styles/app.css` for the new UI elements. 

### Testing
- Syntax/quick checks: ran `node --check` across all `freeforge/src` files which succeeded. 
- BLU validation: ran the repository-specific Python BLU checklist (multiple assertions checking presence and wiring of new features) which passed. 
- Local server smoke: served `freeforge/` with `python3 -m http.server` and verified fetching `index.html`, `src/app.js`, and `styles/app.css` over `http://127.0.0.1:8765` which succeeded. 
- Notes: headless browser screenshot capture was not available in the environment (`No headless browser found`), so visual screenshot tests were skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22caf854988322b5b2fb180c3af88e)