### PR TITLE
Fix blank page caused by duplicate export in models.js

### DIFF
--- a/freeforge/src/features/models.js
+++ b/freeforge/src/features/models.js
@@ -2,6 +2,7 @@ import { S, $, LS, fmtCtx } from '../state.js';
 import { fetchFreeModels } from '../api.js';
 import { toast } from '../ui/toast.js';
 import { showInvalidBanner } from '../ui/screen.js';
+import { renderCtxPill } from '../ui/ctx-pill.js';
 
 function buildOptions(models) {
   const sel = $('model-select');
@@ -48,17 +49,6 @@ export async function loadModels(key) {
   }
 }
 
-export function changeModel(modelId) {
-  const prev = S.selectedModel;
-  S.selectedModel = modelId;
-  $('model-select').value = modelId;
-  LS.set('ff_model', modelId);
-  if (prev !== modelId) {
-    const m = S.models.find(x => x.id === modelId);
-    toast(`Model: ${m?.name || modelId.split('/').pop()}`, 'info');
-  }
-}
-
 export function populateModelsFromState() {
   const sel = $('model-select');
   if (!S.models.length) { sel.innerHTML = '<option value="">No free models</option>'; return; }
@@ -71,10 +61,16 @@ export function populateModelsFromState() {
 
 export function changeModel(modelId) {
   if (!modelId) return;
-  const exists = S.models.find(m => m.id === modelId);
-  if (!exists) { toast('Model unavailable', 'warning'); return; }
+  const model = S.models.find(m => m.id === modelId);
+  if (!model) { toast('Model unavailable', 'warning'); return; }
+
+  const prev = S.selectedModel;
   S.selectedModel = modelId;
   $('model-select').value = modelId;
   LS.set('ff_model', modelId);
-  toast(`Model: ${exists.name || modelId.split('/').pop()}`, 'info');
+  renderCtxPill();
+
+  if (prev !== modelId) {
+    toast(`Model: ${model.name || modelId.split('/').pop()}`, 'info');
+  }
 }


### PR DESCRIPTION
### Motivation
- The app failed to initialize because `models.js` exported `changeModel` twice, causing module evaluation to throw `Identifier 'changeModel' has already been declared` and resulting in a blank page.

### Description
- Removed the duplicate `export function changeModel(...)` and consolidated into a single implementation in `freeforge/src/features/models.js` that validates the model, persists selection, refreshes the context pill, and shows the change toast.
- Added an import of `renderCtxPill` and ensured the chosen model triggers a context update when switched.
- Kept existing model loading and state population behavior intact (no changes to `loadModels` / `populateModelsFromState`).

### Testing
- Verified module import with `node --input-type=module -e "import('./freeforge/src/features/models.js')..."` which succeeded.
- Ran static checks `for f in freeforge/src/**/*.js freeforge/src/*.js; do node --check "$f"; done` which passed.
- Imported the full app module with mocked globals via Node which completed without module evaluation errors.
- Started a local static server `python3 -m http.server 4173 --directory freeforge` and performed an HTTP 200 smoke check which returned 200.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a230422a5408322ba2b14eed2938a3c)