### PR TITLE
Fix #21: replace Tailwind JIT CDN with static stylesheet

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -4,8 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>FreeForge — Free AI Chat</title>
-  <!-- cdn.tailwindcss.com is a dynamic JIT loader; SRI is not applicable (content varies per request) -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.17/tailwind.min.css"
+        integrity="sha384-Br1MdJLeZHETRKXp+xqUrJ1h9M/NMwk2BkpskTNuPjVs+8VhXzMxhCXQRhKuSUkY"
+        crossorigin="anonymous">
   <script src="https://cdn.jsdelivr.net/npm/marked@18.0.4/lib/marked.umd.js"
           integrity="sha384-8RA8Ah4c9upJmKfg5nH01OgjZoQ3mRX+ngrKYWXQYj2dHYxFqYz8POSlii33f0wB"
           crossorigin="anonymous"></script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'none'; script-src 'self' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; worker-src https://cdn.tailwindcss.com blob:; connect-src https://openrouter.ai; style-src 'self' 'unsafe-inline'; img-src 'self' data:; form-action 'none'; base-uri 'none'; frame-ancestors 'none'; object-src 'none'"
+    Content-Security-Policy = "default-src 'none'; script-src 'self' https://cdn.jsdelivr.net; connect-src https://openrouter.ai; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data:; form-action 'none'; base-uri 'none'; frame-ancestors 'none'; object-src 'none'"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "no-referrer"


### PR DESCRIPTION
## Summary
- replace the Tailwind JIT CDN script with a static Tailwind 3.4.17 stylesheet from jsDelivr
- add a matching SHA-384 SRI hash for the stylesheet asset
- narrow the Netlify CSP to remove the old Tailwind worker/script allowances that are no longer needed

## Verification
- confirmed no cdn.tailwindcss.com references remain under reeforge/
- confirmed https://cdn.jsdelivr.net/npm/tailwindcss@3.4.17/tailwind.min.css responds with HTTP 200

Closes #21