### PR TITLE
Fix #51: add inline SVG favicon

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Requires Chrome 97+, Firefox 104+, Safari 15.4+ -->
   <title>FreeForge — Free AI Chat</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%234f46e5'/%3E%3Cpath d='M18 4 8 18h7l-1 10 10-14h-7z' fill='white'/%3E%3C/svg%3E">
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.17/tailwind.min.css"
         integrity="sha384-Br1MdJLeZHETRKXp+xqUrJ1h9M/NMwk2BkpskTNuPjVs+8VhXzMxhCXQRhKuSUkY"


### PR DESCRIPTION
## Summary
- add an inline SVG favicon data URI to freeforge/index.html
- stop the browser from falling back to /favicon.ico on page load
- keep the change isolated to a single HTML head entry

## Verification
- Select-String -Path freeforge/index.html -Pattern ''rel="icon"|favicon|data:image/svg\+xml''
- git show --stat --oneline HEAD~1..HEAD

Fixes #51