### PR TITLE
Fix #31: label icon-only buttons

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -60,7 +60,7 @@
             <div class="relative">
               <input id="ob-key-input" type="password" placeholder="sk-or-v1-..." autocomplete="new-password" spellcheck="false"
                      class="w-full px-3 py-2.5 rounded-xl text-sm bg-zinc-900 border border-zinc-700 text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors pr-10">
-              <button id="ob-toggle-vis" type="button" class="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 transition-colors">
+              <button id="ob-toggle-vis" type="button" aria-label="Show API key" class="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 transition-colors">
                 <svg id="ob-eye-show" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
@@ -148,7 +148,7 @@
         class="nav-icon-btn palette-trigger">
         ⌘
       </button>
-      <button id="settings-btn" title="Settings" class="p-2 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors">
+      <button id="settings-btn" title="Settings" aria-label="Settings" class="p-2 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
@@ -213,7 +213,7 @@
       <div id="input-box" class="flex items-end gap-3 rounded-2xl border border-zinc-700 focus-within:border-indigo-500 transition-colors px-4 py-3" style="background:#27272a">
         <textarea id="msg-input" placeholder="Message FreeForge…" rows="1" maxlength="32000"
                   class="flex-1 bg-transparent text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none leading-relaxed"></textarea>
-        <button id="send-btn" class="gradient-btn flex-shrink-0 w-9 h-9 rounded-xl flex items-center justify-center transition-all">
+        <button id="send-btn" aria-label="Send message" class="gradient-btn flex-shrink-0 w-9 h-9 rounded-xl flex items-center justify-center transition-all">
           <svg id="send-icon" class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
           </svg>
@@ -233,7 +233,7 @@
   <div class="relative w-full max-w-md rounded-2xl border border-zinc-800 p-6 z-10 modal-card" style="background:#18181b">
     <div class="flex items-center justify-between mb-5">
       <h2 class="text-lg font-semibold text-zinc-100">Settings</h2>
-      <button id="close-settings-btn" class="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors">
+      <button id="close-settings-btn" aria-label="Close settings" class="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
         </svg>

--- a/freeforge/src/app.js
+++ b/freeforge/src/app.js
@@ -57,6 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const inp = $('ob-key-input');
     const show = inp.type === 'password';
     inp.type = show ? 'text' : 'password';
+    $('ob-toggle-vis').setAttribute('aria-label', show ? 'Hide API key' : 'Show API key');
     $('ob-eye-show').classList.toggle('hidden', show);
     $('ob-eye-hide').classList.toggle('hidden', !show);
   });

--- a/freeforge/src/ui/messages.js
+++ b/freeforge/src/ui/messages.js
@@ -37,6 +37,7 @@ export function setStreamMode(active) {
   S.streaming = active;
   $('send-icon').classList.toggle('hidden', active);
   $('stop-icon').classList.toggle('hidden', !active);
+  $('send-btn').setAttribute('aria-label', active ? 'Stop streaming' : 'Send message');
 }
 
 export function renderAllMessages() {


### PR DESCRIPTION
## Summary
- add accessible names to the icon-only onboarding, settings, send, and close controls
- update the API key visibility toggle label when the control switches between show and hide states
- update the send button label when the control switches into stop-streaming mode

## Verification
- Select-String -Path freeforge/index.html -Pattern ''aria-label="Show API key"|aria-label="Settings"|aria-label="Send message"|aria-label="Close settings"''
- Select-String -Path freeforge/src/app.js,freeforge/src/ui/messages.js -Pattern ''setAttribute\(''
- git show --stat --oneline HEAD~1..HEAD

Fixes #31