### PR TITLE
Fix #33: label mobile New Chat button

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -132,11 +132,11 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
         </svg>
       </button>
-      <button id="new-chat-btn" class="gradient-btn flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-white transition-all">
+      <button id="new-chat-btn" aria-label="New Chat" class="gradient-btn flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-white transition-all">
         <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4"/>
         </svg>
-        <span class="hidden sm:block">New Chat</span>
+        <span class="hidden sm:block" aria-hidden="true">New Chat</span>
       </button>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- add an explicit accessible name to the New Chat button so it stays named on mobile
- hide the responsive visible text from assistive technology to avoid duplicate reading on larger screens
- keep the fix isolated to freeforge/index.html

## Verification
- Select-String -Path freeforge/index.html -Pattern ''new-chat-btn|aria-label="New Chat"|aria-hidden="true"''
- git show --stat --oneline HEAD~1..HEAD

Fixes #33