### PR TITLE
Fix #38: remove findLastIndex polyfill

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Requires Chrome 97+, Firefox 104+, Safari 15.4+ -->
   <title>FreeForge — Free AI Chat</title>
   <!-- cdn.tailwindcss.com is a dynamic JIT loader; SRI is not applicable (content varies per request) -->
   <script src="https://cdn.tailwindcss.com"></script>

--- a/freeforge/src/state.js
+++ b/freeforge/src/state.js
@@ -1,12 +1,3 @@
-if (!Array.prototype.findLastIndex) {
-  Array.prototype.findLastIndex = function (fn) {
-    for (let i = this.length - 1; i >= 0; i--) {
-      if (fn(this[i], i, this)) return i;
-    }
-    return -1;
-  };
-}
-
 export const S = {
   apiKey: null,
   models: [],


### PR DESCRIPTION
## Summary
- remove the dead Array.prototype.findLastIndex polyfill from freeforge/src/state.js
- document the minimum supported browser baseline in freeforge/index.html
- keep the cleanup scoped to the runtime baseline this app already requires

## Verification
- Select-String -Path freeforge/src/*.js,freeforge/src/*/*.js -Pattern ''findLastIndex''
- Select-String -Path freeforge/index.html -Pattern ''Requires Chrome 97\+, Firefox 104\+, Safari 15.4\+''
- git show --stat --oneline HEAD~1..HEAD

Fixes #38