### PR TITLE
Fix #45: wrap password inputs in forms

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -53,19 +53,21 @@
 
         <div>
           <label class="block text-xs font-medium text-zinc-400 mb-1.5">API Key</label>
-          <div class="relative">
-            <input id="ob-key-input" type="password" placeholder="sk-or-v1-..." autocomplete="off" spellcheck="false"
-                   class="w-full px-3 py-2.5 rounded-xl text-sm bg-zinc-900 border border-zinc-700 text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors pr-10">
-            <button id="ob-toggle-vis" type="button" class="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 transition-colors">
-              <svg id="ob-eye-show" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
-              </svg>
-              <svg id="ob-eye-hide" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"/>
-              </svg>
-            </button>
-          </div>
+          <form autocomplete="off" onsubmit="return false;">
+            <div class="relative">
+              <input id="ob-key-input" type="password" placeholder="sk-or-v1-..." autocomplete="new-password" spellcheck="false"
+                     class="w-full px-3 py-2.5 rounded-xl text-sm bg-zinc-900 border border-zinc-700 text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors pr-10">
+              <button id="ob-toggle-vis" type="button" class="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 transition-colors">
+                <svg id="ob-eye-show" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                </svg>
+                <svg id="ob-eye-hide" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"/>
+                </svg>
+              </button>
+            </div>
+          </form>
           <p id="ob-key-error" class="mt-1.5 text-xs text-red-400 hidden"></p>
         </div>
 
@@ -223,8 +225,10 @@
       </div>
       <div>
         <label class="block text-xs font-medium text-zinc-400 mb-1.5">Update API Key</label>
-        <input id="settings-new-key" type="password" placeholder="sk-or-v1-…" autocomplete="off"
-               class="w-full px-3 py-2.5 rounded-xl text-sm bg-zinc-900 border border-zinc-700 text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors">
+        <form autocomplete="off" onsubmit="return false;">
+          <input id="settings-new-key" type="password" placeholder="sk-or-v1-…" autocomplete="new-password"
+                 class="w-full px-3 py-2.5 rounded-xl text-sm bg-zinc-900 border border-zinc-700 text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors">
+        </form>
         <p id="settings-key-error" class="mt-1.5 text-xs text-red-400 hidden"></p>
       </div>
       <button id="settings-update-btn" class="gradient-btn w-full py-2.5 rounded-xl text-sm font-semibold text-white transition-all">


### PR DESCRIPTION
## Summary
- wrap both API-key password fields in non-submitting forms so browser and password-manager heuristics have proper context
- switch each password input to autocomplete="new-password" to reduce unwanted saved-credential autofill
- keep the existing JS-driven save and update flow intact

## Verification
- Select-String -Path freeforge/index.html -Pattern ''<form autocomplete="off" onsubmit="return false;">|autocomplete="new-password"|ob-key-input|settings-new-key''
- git show --stat --oneline HEAD~1..HEAD

Fixes #45