### PR TITLE
Fix #48: add local error log

### DIFF
--- a/freeforge/src/app.js
+++ b/freeforge/src/app.js
@@ -1,4 +1,4 @@
-import { S, $, LS, getStoredKey } from './state.js';
+import { S, $, LS, getStoredKey, recordError, getErrorLog } from './state.js';
 import { showScreen, hideInvalidBanner } from './ui/screen.js';
 import { renderAllMessages, scrollBottom } from './ui/messages.js';
 import { toast } from './ui/toast.js';
@@ -23,7 +23,31 @@ async function init() {
   await loadModels(savedKey);
 }
 
+function installErrorCapture() {
+  window.addEventListener('error', e => {
+    recordError({
+      type: 'error',
+      msg: e.message || 'Unknown error',
+      src: e.filename || '',
+      line: e.lineno || 0,
+      col: e.colno || 0,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', e => {
+    const reason = e.reason;
+    recordError({
+      type: 'unhandledrejection',
+      msg: reason?.message || String(reason),
+    });
+  });
+
+  // Local-only inspection hook for debugging without external telemetry.
+  window.__freeforgeGetErrorLog = getErrorLog;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+  installErrorCapture();
 
   // onboarding
   $('ob-toggle-vis').addEventListener('click', () => {

--- a/freeforge/src/state.js
+++ b/freeforge/src/state.js
@@ -26,6 +26,17 @@ export const LS = {
 export const $ = id => document.getElementById(id);
 export const esc = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 export const uid = () => Math.random().toString(36).slice(2) + Date.now().toString(36);
+const ERROR_LOG_LIMIT = 50;
+const errorLog = [];
+
+export function recordError(entry) {
+  errorLog.push({ ts: Date.now(), ...entry });
+  if (errorLog.length > ERROR_LOG_LIMIT) errorLog.shift();
+}
+
+export function getErrorLog() {
+  return errorLog.slice();
+}
 
 export function getStoredKey() {
   try {


### PR DESCRIPTION
## Summary
- add a capped in-memory error log in freeforge/src/state.js
- capture window error and unhandledrejection events during app startup
- expose a local-only debug getter without adding third-party telemetry or persistence

## Verification
- Select-String -Path freeforge/src/state.js,freeforge/src/app.js -Pattern ''recordError|getErrorLog|unhandledrejection|window.__freeforgeGetErrorLog|ERROR_LOG_LIMIT''
- git show --stat --oneline HEAD~1..HEAD

Fixes #48