### PR TITLE
Fix #47: add package manifest

### DIFF
--- a/freeforge/package.json
+++ b/freeforge/package.json
@@ -1,3 +1,17 @@
 {
-  "type": "module"
+  "name": "freeforge",
+  "version": "1.0.0",
+  "description": "Zero-build browser chat UI for OpenRouter free models",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  },
+  "dependencies": {
+    "dompurify": "3.4.8",
+    "marked": "18.0.4"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.0"
+  }
 }


### PR DESCRIPTION
## Summary
- add freeforge/package.json as a machine-readable dependency manifest
- mirror the currently shipped CDN versions for marked and DOMPurify
- enable tooling such as npm audit and Dependabot without changing the runtime loading model

## Verification
- Get-Content freeforge/package.json
- Select-String -Path freeforge/index.html -Pattern ''marked@|dompurify@|tailwindcss''
- git show --stat --oneline HEAD~1..HEAD

Fixes #47