### PR TITLE
Fix #41: add message length limit

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -185,7 +185,7 @@
   <div class="border-t border-zinc-800 px-4 py-3 flex-shrink-0" style="background:#18181b">
     <div class="max-w-3xl mx-auto">
       <div id="input-box" class="flex items-end gap-3 rounded-2xl border border-zinc-700 focus-within:border-indigo-500 transition-colors px-4 py-3" style="background:#27272a">
-        <textarea id="msg-input" placeholder="Message FreeForge…" rows="1"
+        <textarea id="msg-input" placeholder="Message FreeForge…" rows="1" maxlength="32000"
                   class="flex-1 bg-transparent text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none leading-relaxed"></textarea>
         <button id="send-btn" class="gradient-btn flex-shrink-0 w-9 h-9 rounded-xl flex items-center justify-center transition-all">
           <svg id="send-icon" class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/freeforge/src/features/chat.js
+++ b/freeforge/src/features/chat.js
@@ -6,6 +6,10 @@ import { renderAllMessages, scrollBottom, setStreamMode } from '../ui/messages.j
 export async function sendMessage(text) {
   text = text.trim();
   if (!text || S.streaming) return;
+  if (text.length > 32000) {
+    toast('Message too long (max 32,000 characters)', 'error');
+    return;
+  }
   if (!S.selectedModel) { toast('Select a model first', 'warning'); return; }
 
   const isFirst = S.messages.filter(m => m.role === 'user').length === 0;


### PR DESCRIPTION
## Summary
- add a 32,000 character maxlength to the chat textarea
- add a matching early guard in sendMessage() to stop oversized prompts before any API call
- keep the validation local and aligned across UI and programmatic entry paths

## Verification
- Select-String -Path freeforge/index.html,freeforge/src/features/chat.js -Pattern ''maxlength="32000"|32000|Message too long''
- git show --stat --oneline HEAD~1..HEAD

Fixes #41