### PR TITLE
Fix #40: replace clear-key confirm

### DIFF
--- a/freeforge/src/features/settings.js
+++ b/freeforge/src/features/settings.js
@@ -4,14 +4,39 @@ import { showScreen, hideInvalidBanner } from '../ui/screen.js';
 import { toast } from '../ui/toast.js';
 import { populateModelsFromState } from './models.js';
 
+const CLEAR_CONFIRM_MS = 3000;
+
+function resetClearButton(btn) {
+  if (btn._confirmTimer) {
+    clearTimeout(btn._confirmTimer);
+    btn._confirmTimer = null;
+  }
+  btn.dataset.confirm = '';
+  btn.textContent = 'Clear Key';
+  btn.classList.remove('bg-red-600', 'text-white');
+}
+
+function executeClearKey() {
+  clearStoredKey();
+  ['ff_msgs', 'ff_model'].forEach(k => LS.del(k));
+  S.apiKey = null;
+  S.messages = [];
+  S.models = [];
+  S.selectedModel = null;
+  closeSettings();
+  showScreen('onboarding');
+}
+
 export function openSettings() {
   $('settings-key-display').textContent = maskKey(S.apiKey);
   $('settings-new-key').value = '';
   $('settings-key-error').classList.add('hidden');
+  resetClearButton($('settings-clear-btn'));
   $('settings-modal').classList.add('open');
 }
 
 export function closeSettings() {
+  resetClearButton($('settings-clear-btn'));
   $('settings-modal').classList.remove('open');
 }
 
@@ -49,13 +74,15 @@ export async function updateKey() {
 }
 
 export function clearKey() {
-  if (!confirm('Clear your API key? You will be taken back to setup.')) return;
-  clearStoredKey();
-  ['ff_msgs', 'ff_model'].forEach(k => LS.del(k));
-  S.apiKey = null;
-  S.messages = [];
-  S.models = [];
-  S.selectedModel = null;
-  closeSettings();
-  showScreen('onboarding');
+  const btn = $('settings-clear-btn');
+  if (btn.dataset.confirm === 'pending') {
+    resetClearButton(btn);
+    executeClearKey();
+    return;
+  }
+
+  btn.dataset.confirm = 'pending';
+  btn.textContent = 'Click again to confirm';
+  btn.classList.add('bg-red-600', 'text-white');
+  btn._confirmTimer = setTimeout(() => resetClearButton(btn), CLEAR_CONFIRM_MS);
 }


### PR DESCRIPTION
## Summary
- replace the blocking clear-key confirm() dialog with a two-step inline confirmation on the existing button
- auto-reset the pending destructive state after 3 seconds or when the settings modal closes
- keep the destructive clear logic centralized without adding new modal markup

## Verification
- Select-String -Path freeforge/src/features/settings.js -Pattern ''CLEAR_CONFIRM_MS|resetClearButton|executeClearKey|dataset.confirm|Click again to confirm''
- git show --stat --oneline HEAD~1..HEAD

Fixes #40