### PR TITLE
Fix #42: rank models dynamically

### DIFF
--- a/freeforge/src/features/models.js
+++ b/freeforge/src/features/models.js
@@ -3,6 +3,14 @@ import { fetchFreeModels } from '../api.js';
 import { toast } from '../ui/toast.js';
 import { showInvalidBanner } from '../ui/screen.js';
 
+function rankModels(models) {
+  return [...models].sort((a, b) => {
+    const ctxDelta = (b.context_length || 0) - (a.context_length || 0);
+    if (ctxDelta !== 0) return ctxDelta;
+    return (a.name || a.id).localeCompare(b.name || b.id);
+  });
+}
+
 function buildOptions(models) {
   const sel = $('model-select');
   sel.innerHTML = '';
@@ -20,7 +28,7 @@ export async function loadModels(key) {
   const sel = $('model-select');
   sel.innerHTML = '<option value="">Loading models…</option>';
   try {
-    const models = await fetchFreeModels(key);
+    const models = rankModels(await fetchFreeModels(key));
     S.models = models;
     if (!models.length) { sel.innerHTML = '<option value="">No free models found</option>'; return; }
     buildOptions(models);
@@ -30,15 +38,7 @@ export async function loadModels(key) {
       sel.value = saved;
       S.selectedModel = saved;
     } else {
-      const preferred = [
-        'meta-llama/llama-3.1-8b-instruct:free',
-        'meta-llama/llama-3-8b-instruct:free',
-        'mistralai/mistral-7b-instruct:free',
-        'google/gemma-2-9b-it:free',
-        'qwen/qwen-2-7b-instruct:free',
-        'microsoft/phi-3-mini-128k-instruct:free',
-      ];
-      const pick = preferred.find(p => models.find(m => m.id === p)) || models[0]?.id;
+      const pick = models[0]?.id;
       if (pick) { sel.value = pick; S.selectedModel = pick; LS.set('ff_model', pick); }
     }
   } catch (e) {
@@ -51,6 +51,7 @@ export async function loadModels(key) {
 export function populateModelsFromState() {
   const sel = $('model-select');
   if (!S.models.length) { sel.innerHTML = '<option value="">No free models</option>'; return; }
+  S.models = rankModels(S.models);
   buildOptions(S.models);
   const saved = LS.get('ff_model');
   const validSaved = saved && S.models.find(m => m.id === saved);


### PR DESCRIPTION
## Summary
- remove the hardcoded preferred model ID list from models.js
- rank free models dynamically by context length, then by name/id as a stable tiebreaker
- reuse the same ranking helper for both initial load and later repopulation

## Verification
- Select-String -Path freeforge/src/features/models.js -Pattern ''rankModels|context_length|preferred|llama-3.1-8b-instruct|localeCompare''
- git show --stat --oneline HEAD~1..HEAD

Fixes #42