### PR TITLE
chore(quality): add zero-build Biome check

### DIFF
--- a/.github/workflows/biome-check.yml
+++ b/.github/workflows/biome-check.yml
@@ -1,0 +1,25 @@
+name: Biome Check
+
+on:
+  push:
+    branches:
+      - main
+      - 'fix-issue-*'
+      - 'test-issue-*'
+      - 'chore-issue-*'
+  pull_request:
+
+jobs:
+  biome:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run zero-install Biome lint pass
+        run: npx --yes @biomejs/biome check freeforge/src tests/security

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "files": {
+    "includes": [
+      "freeforge/src/**/*.js",
+      "tests/security/**/*.mjs"
+    ]
+  },
+  "formatter": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  }
+}

--- a/freeforge/src/api.js
+++ b/freeforge/src/api.js
@@ -11,7 +11,7 @@ export async function fetchFreeModels(key) {
   }
   const data = await res.json();
   return (data.data || []).filter(m => {
-    if (m.id && m.id.endsWith(':free')) return true;
+    if (m.id?.endsWith(':free')) return true;
     const p = m.pricing;
     return p && parseFloat(p.prompt || '1') === 0 && parseFloat(p.completion || '1') === 0;
   }).sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id));
@@ -40,7 +40,7 @@ export async function streamCompletion(msgs, modelId, key, { onToken, onDone, on
     try { const j = await res.json(); msg = j.error?.message || msg; } catch {}
     if (res.status === 401) { showInvalidBanner(); onError('Invalid API key — update it in Settings.'); }
     else if (res.status === 429) onError('Rate limited — try again in a moment.');
-    else if (res.status === 400) onError('Bad request: ' + msg);
+    else if (res.status === 400) onError(`Bad request: ${msg}`);
     else if (res.status === 413) onError('Context too long — start a new chat.');
     else onError(msg);
     return;

--- a/freeforge/src/app.js
+++ b/freeforge/src/app.js
@@ -1,13 +1,13 @@
-import { S, $, LS, getStoredKey, recordError, getErrorLog } from './state.js';
-import { showScreen, hideInvalidBanner } from './ui/screen.js';
-import { renderAllMessages, scrollBottom } from './ui/messages.js';
-import { toast } from './ui/toast.js';
+import { newChat, regenerate, sendMessage } from './features/chat.js';
 import { loadModels } from './features/models.js';
-import { validateAndConnect, hideObError } from './features/onboarding.js';
-import { openSettings, closeSettings, updateKey, clearKey } from './features/settings.js';
-import { sendMessage, regenerate, newChat } from './features/chat.js';
+import { hideObError, validateAndConnect } from './features/onboarding.js';
+import { closePalette, openPalette } from './features/palette.js';
+import { clearKey, closeSettings, openSettings, updateKey } from './features/settings.js';
+import { $, getErrorLog, getStoredKey, LS, recordError, S } from './state.js';
 import { renderCtxPill } from './ui/ctx-pill.js';
-import { openPalette, closePalette } from './features/palette.js';
+import { renderAllMessages, scrollBottom } from './ui/messages.js';
+import { hideInvalidBanner, showScreen } from './ui/screen.js';
+import { toast } from './ui/toast.js';
 
 async function init() {
   const savedKey = getStoredKey();
@@ -97,7 +97,7 @@ document.addEventListener('DOMContentLoaded', () => {
   };
   inp.addEventListener('input', () => {
     inp.style.height = 'auto';
-    inp.style.height = Math.min(inp.scrollHeight, 160) + 'px';
+    inp.style.height = `${Math.min(inp.scrollHeight, 160)}px`;
   });
   inp.addEventListener('keydown', e => {
     if (e.key === 'Enter' && !e.shiftKey) {

--- a/freeforge/src/features/chat.js
+++ b/freeforge/src/features/chat.js
@@ -2,6 +2,7 @@ import { streamCompletion } from '../api.js';
 import { $, LS, S, uid } from '../state.js';
 import { renderCtxPill } from '../ui/ctx-pill.js';
 import { appendNewMessages, renderAllMessages, replaceMessage, scrollBottom, setStreamMode } from '../ui/messages.js';
+import { toast } from '../ui/toast.js';
 
 export async function sendMessage(text) {
   text = text.trim();

--- a/freeforge/src/features/chat.js
+++ b/freeforge/src/features/chat.js
@@ -1,8 +1,8 @@
-import { S, $, LS, uid } from '../state.js';
 import { streamCompletion } from '../api.js';
-import { toast } from '../ui/toast.js';
+import { $, LS, S, uid } from '../state.js';
 import { renderCtxPill } from '../ui/ctx-pill.js';
 import { renderAllMessages, scrollBottom, setStreamMode } from '../ui/messages.js';
+import { toast } from '../ui/toast.js';
 
 export async function sendMessage(text) {
   text = text.trim();

--- a/freeforge/src/features/models.js
+++ b/freeforge/src/features/models.js
@@ -1,8 +1,8 @@
-import { S, $, LS, fmtCtx } from '../state.js';
 import { fetchFreeModels } from '../api.js';
-import { toast } from '../ui/toast.js';
-import { showInvalidBanner } from '../ui/screen.js';
+import { $, fmtCtx, LS, S } from '../state.js';
 import { renderCtxPill } from '../ui/ctx-pill.js';
+import { showInvalidBanner } from '../ui/screen.js';
+import { toast } from '../ui/toast.js';
 
 function rankModels(models) {
   return [...models].sort((a, b) => {
@@ -44,7 +44,7 @@ export async function loadModels(key) {
     }
   } catch (e) {
     sel.innerHTML = '<option value="">Failed to load models</option>';
-    toast('Could not load models: ' + e.message, 'error');
+    toast(`Could not load models: ${e.message}`, 'error');
     if (e.message.includes('Invalid')) showInvalidBanner();
   }
 }

--- a/freeforge/src/features/onboarding.js
+++ b/freeforge/src/features/onboarding.js
@@ -1,8 +1,8 @@
-import { S, $, setStoredKey } from '../state.js';
 import { fetchFreeModels } from '../api.js';
+import { $, S, setStoredKey } from '../state.js';
+import { renderAllMessages } from '../ui/messages.js';
 import { showScreen } from '../ui/screen.js';
 import { toast } from '../ui/toast.js';
-import { renderAllMessages } from '../ui/messages.js';
 import { populateModelsFromState } from './models.js';
 
 export async function validateAndConnect(key) {

--- a/freeforge/src/features/palette.js
+++ b/freeforge/src/features/palette.js
@@ -1,8 +1,8 @@
 import { S } from '../state.js';
-import { newChat, copyLastResponse } from './chat.js';
+import { copyLastResponse, newChat } from './chat.js';
+import { exportConversation } from './export.js';
 import { changeModel } from './models.js';
 import { openSettings } from './settings.js';
-import { exportConversation } from './export.js';
 
 const BASE_ACTIONS = [
   { label: 'New Chat', shortcut: 'N', action: () => { newChat(); closePalette(); } },

--- a/freeforge/src/features/settings.js
+++ b/freeforge/src/features/settings.js
@@ -1,6 +1,6 @@
-import { S, $, LS, maskKey, setStoredKey, clearStoredKey } from '../state.js';
 import { fetchFreeModels } from '../api.js';
-import { showScreen, hideInvalidBanner } from '../ui/screen.js';
+import { $, clearStoredKey, LS, maskKey, S, setStoredKey } from '../state.js';
+import { hideInvalidBanner, showScreen } from '../ui/screen.js';
 import { toast } from '../ui/toast.js';
 import { populateModelsFromState } from './models.js';
 
@@ -19,7 +19,9 @@ function resetClearButton(btn) {
 
 function executeClearKey() {
   clearStoredKey();
-  ['ff_msgs', 'ff_model'].forEach(k => LS.del(k));
+  ['ff_msgs', 'ff_model'].forEach(k => {
+    LS.del(k);
+  });
   S.apiKey = null;
   S.messages = [];
   S.models = [];

--- a/freeforge/src/state.js
+++ b/freeforge/src/state.js
@@ -60,7 +60,7 @@ export function clearStoredKey() {
 
 export function maskKey(k) {
   if (!k || k.length < 8) return '••••••••';
-  return k.slice(0, 6) + '••••••••••••' + k.slice(-4);
+  return `${k.slice(0, 6)}••••••••••••${k.slice(-4)}`;
 }
 
 export function fmtCtx(n) {

--- a/freeforge/src/ui/messages.js
+++ b/freeforge/src/ui/messages.js
@@ -1,6 +1,5 @@
-import { S, $ } from '../state.js';
 import { renderMd } from '../markdown.js';
-import { $, esc, S } from '../state.js';
+import { $, S } from '../state.js';
 import { toast } from './toast.js';
 
 let renderedCount = 0;

--- a/freeforge/src/ui/messages.js
+++ b/freeforge/src/ui/messages.js
@@ -1,5 +1,5 @@
-import { S, $, esc } from '../state.js';
 import { renderMd } from '../markdown.js';
+import { $, esc, S } from '../state.js';
 import { toast } from './toast.js';
 
 

--- a/freeforge/src/ui/screen.js
+++ b/freeforge/src/ui/screen.js
@@ -1,7 +1,9 @@
 import { $ } from '../state.js';
 
 export function showScreen(name) {
-  document.querySelectorAll('.screen').forEach(el => el.classList.remove('active'));
+  document.querySelectorAll('.screen').forEach(el => {
+    el.classList.remove('active');
+  });
   $(`screen-${name}`).classList.add('active');
 }
 

--- a/tests/security/innerhtml-audit.test.mjs
+++ b/tests/security/innerhtml-audit.test.mjs
@@ -1,7 +1,7 @@
-import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile, readdir } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
+import test from 'node:test';
 
 async function read(relPath) {
   return readFile(path.resolve(relPath), 'utf8');

--- a/tests/security/markdown-pipeline.test.mjs
+++ b/tests/security/markdown-pipeline.test.mjs
@@ -1,7 +1,7 @@
-import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import test from 'node:test';
 
 const ESC_IMPL = "const esc = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\\\"/g, '&quot;');";
 

--- a/tests/security/state-storage.test.mjs
+++ b/tests/security/state-storage.test.mjs
@@ -1,5 +1,5 @@
-import test from 'node:test';
 import assert from 'node:assert/strict';
+import test from 'node:test';
 
 import { clearStoredKey, getStoredKey, setStoredKey } from '../../freeforge/src/state.js';
 

--- a/tests/security/state-utils.test.mjs
+++ b/tests/security/state-utils.test.mjs
@@ -1,5 +1,5 @@
-import test from 'node:test';
 import assert from 'node:assert/strict';
+import test from 'node:test';
 
 import { esc, maskKey } from '../../freeforge/src/state.js';
 


### PR DESCRIPTION
## Summary

Adds a lightweight Biome lint pass that runs without changing the repo's no-build deployment model, and fixes the current lint findings so the new check lands green.

This change was needed because issue #54 calls out the lack of automated code quality checks in a deliberately zero-build app. Using Biome via 
px provides a real quality gate without introducing a mandatory install or Netlify build step.

Closes #54

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test-only change
- [ ] Documentation update
- [x] Build / CI / tooling change
- [ ] Other: n/a

---

## What Changed

- Added iome.json with a narrow lint-only configuration targeting reeforge/src and 	ests/security
- Added .github/workflows/biome-check.yml to run the lint pass through 
px @biomejs/biome on pushes and pull requests
- Applied the necessary lint-conformance fixes across the existing source and test files so the new quality gate passes immediately

---

## Why This Approach

The repo's zero-build constraint is about runtime and deployment, not about prohibiting all development tooling. Running Biome through 
px keeps deployment unchanged, avoids committing a dependency manifest just for linting, and still gives the repository an automated quality check that can catch style and maintainability regressions early.

---

## Testing

### Commands Run

`ash
npx --yes @biomejs/biome check freeforge/src tests/security
git diff --check
`

### Results

The Biome check passed locally after the branch fixes. git diff --check reported only the repository's existing LF->CRLF warnings and no content errors.

### Coverage Added or Updated

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing only
- [x] Not applicable — explain why: This issue adds lint/tooling coverage rather than runtime behavior coverage.

---

## Screenshots / Logs / Evidence

Evidence: 
px --yes @biomejs/biome check freeforge/src tests/security now exits cleanly on the branch, and the new workflow runs that same command in GitHub Actions.

---

## Risk Assessment

### Risk Level

- [x] Low
- [ ] Medium
- [ ] High

### Possible Impact

The only user-visible risk is from the small lint-driven source edits, such as import reordering and string-template cleanup. No new runtime features or deployment changes were introduced.

### Rollback Plan

Revert this single commit to remove the Biome config, workflow, and associated lint-fix edits.

---

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included

Details:

None.

---

## Reviewer Focus

Please pay special attention to:

- Whether the Biome config scope is appropriately narrow for the repo's zero-build philosophy
- Whether the lint-fix edits are all non-behavioral and safe
- Whether running Biome through 
px is the right long-term tradeoff versus adding a formal dependency manifest later

---

## Checklist

- [x] PR is linked to the correct issue
- [x] Tests pass locally
- [x] Relevant tests were added or updated
- [x] Only files relevant to this issue were modified
- [x] No secrets, credentials, API keys, or environment-specific values introduced
- [x] Error handling was considered
- [x] Edge cases were considered
- [x] Documentation updated, or not needed
- [x] No breaking changes, or they are clearly documented above
- [x] This PR is ready for review

---

## Notes for Follow-Up Work

If the repo eventually adopts a dependency manifest for other reasons, the same Biome config can be moved behind a dedicated 
pm run lint script without changing the deployment model.