### PR TITLE
fix: add 15s fetch timeout to fetchFreeModels to prevent indefinite loading spinner

### DIFF
--- a/freeforge/src/api.js
+++ b/freeforge/src/api.js
@@ -1,20 +1,27 @@
 import { showInvalidBanner } from './ui/screen.js';
 
 export async function fetchFreeModels(key) {
-  const res = await fetch('https://openrouter.ai/api/v1/models', {
-    headers: { 'Authorization': `Bearer ${key}` },
-  });
-  if (!res.ok) {
-    if (res.status === 401) throw new Error('Invalid API key');
-    if (res.status === 429) throw new Error('Rate limited — try again shortly');
-    throw new Error(`Failed to fetch models (${res.status})`);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15000);
+  try {
+    const res = await fetch('https://openrouter.ai/api/v1/models', {
+      headers: { 'Authorization': `Bearer ${key}` },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      if (res.status === 401) throw new Error('Invalid API key');
+      if (res.status === 429) throw new Error('Rate limited — try again shortly');
+      throw new Error(`Failed to fetch models (${res.status})`);
+    }
+    const data = await res.json();
+    return (data.data || []).filter(m => {
+      if (m.id?.endsWith(':free')) return true;
+      const p = m.pricing;
+      return p && parseFloat(p.prompt || '1') === 0 && parseFloat(p.completion || '1') === 0;
+    }).sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id));
+  } finally {
+    clearTimeout(timeoutId);
   }
-  const data = await res.json();
-  return (data.data || []).filter(m => {
-    if (m.id?.endsWith(':free')) return true;
-    const p = m.pricing;
-    return p && parseFloat(p.prompt || '1') === 0 && parseFloat(p.completion || '1') === 0;
-  }).sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id));
 }
 
 export async function streamCompletion(msgs, modelId, key, { onToken, onDone, onError, signal }) {


### PR DESCRIPTION
Closes #86

**Problem:** `fetchFreeModels` in `api.js` made a bare `fetch()` call with no AbortController, no signal, and no timeout. If the OpenRouter `/models` endpoint was slow or non-responsive, the model selector showed "Loading models…" indefinitely with no user escape path.

**Fix:** Added a 15-second AbortController timeout around the fetch call. The controller and timer are always cleaned up in a `finally` block regardless of success, error, or abort.

**How it fails gracefully:** All three callers (`loadModels`, `validateAndConnect`, `updateKey`) already wrap `fetchFreeModels` in try/catch and show user-facing error messages (toast `"Could not load models: …"`, `"Network error — check your connection."`, etc.). Timeout errors propagate naturally through those existing handlers — no caller changes needed.

**Verification:**
- `node --check freeforge/src/api.js` — syntax OK
- `npx @biomejs/biome lint` — 20 files checked, 0 issues
- `node tests/security/*.test.mjs` — all pass
- Manual logic trace confirms timeout fires correctly and is cleaned up on success
