### PR TITLE
fix(a11y): add aria-selected and aria-activedescendant to command palette items

### DIFF
--- a/freeforge/src/features/palette.js
+++ b/freeforge/src/features/palette.js
@@ -33,7 +33,9 @@ function render(query = '') {
   list.innerHTML = '';
   filteredActions.forEach((a, i) => {
     const li = document.createElement('li');
+    li.id = `cmd-item-${i}`;
     li.role = 'option';
+    li.setAttribute('aria-selected', String(i === activeIndex));
     li.className = i === activeIndex ? 'cmd-item cmd-active' : 'cmd-item';
     li.textContent = a.label;
     if (a.shortcut) {
@@ -44,6 +46,8 @@ function render(query = '') {
     li.addEventListener('click', () => a.action());
     list.appendChild(li);
   });
+  const srch = document.getElementById('cmd-search');
+  if (srch) srch.setAttribute('aria-activedescendant', filteredActions.length ? `cmd-item-${activeIndex}` : '');
 }
 
 export function openPalette() {


### PR DESCRIPTION
## Summary

- Adds `aria-selected` attribute to every `li[role=option]` in the command palette — `true` for the active item, `false` for others
- Assigns `id="cmd-item-{i}"` to each option so the input can reference the active item
- Sets `aria-activedescendant` on `#cmd-search` to point at the active item ID on every render

## Root Cause

`palette.js` set only a CSS class (`cmd-active`) to indicate the highlighted command. Screen readers cannot observe CSS classes, so there was no programmatic signal for which item was selected when using arrow keys (WCAG 2.1 SC 4.1.2).

## Scoped Changes

- `freeforge/src/features/palette.js` — `render()` function only; 4 lines added

## Tests and Results

```
node --test tests/security/*.test.mjs
# tests 19 / pass 19 / fail 0
```

## Risk

Low — purely additive ARIA attribute changes; no behavior or DOM structure modified.

## Rollback

Revert commit `43f6225`. No data migration required.

## Dependencies

None.

Closes #87