### PR TITLE
fix(security): add Strict-Transport-Security header with preload directive

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,4 @@
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "no-referrer"
     Permissions-Policy = "geolocation=(), microphone=(), camera=()"
+    Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"


### PR DESCRIPTION
## Summary

- Adds `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` to `netlify.toml`

## Root Cause

The header block in `netlify.toml` was missing HSTS. Browsers did not cache HTTPS-only enforcement for this origin, leaving it ineligible for the HSTS preload list and unprotected against SSL-stripping attacks.

## Scoped Changes

- `netlify.toml` — one line added to `[headers.values]`

## Tests and Results

```
grep 'Strict-Transport-Security' netlify.toml
# → Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"

node --test tests/security/*.test.mjs
# tests 19 / pass 19 / fail 0
```

## Risk

Low — header addition only; no application code changed. `max-age=63072000` (2 years) matches HSTS preload list requirements.

## Rollback

Remove the `Strict-Transport-Security` line from `netlify.toml`. No data migration required.

## Dependencies

None. (F-011 CSP reporting is a separate concern and can merge independently.)

Closes #90