### PR TITLE
fix(storage): warn user when localStorage quota is exceeded

### DIFF
--- a/freeforge/src/features/chat.js
+++ b/freeforge/src/features/chat.js
@@ -83,7 +83,7 @@ export async function sendMessage(text) {
       S.streamTarget = null;
       setStreamMode(false);
       setLiveRegion('sr-status', 'Response complete');
-      LS.set('ff_msgs', S.messages);
+      if (!LS.set('ff_msgs', S.messages)) toast('Storage quota exceeded — conversation history may not persist after reload', 'warning', 8000);
       if (!replaceMessage(asstMsg, true)) renderAllMessages();
       renderCtxPill();
       scrollBottom();

--- a/freeforge/src/state.js
+++ b/freeforge/src/state.js
@@ -14,7 +14,7 @@ export const S = {
 
 export const LS = {
   get(k) { try { const v = localStorage.getItem(k); return v ? JSON.parse(v) : null; } catch { return null; } },
-  set(k, v) { try { localStorage.setItem(k, JSON.stringify(v)); } catch {} },
+  set(k, v) { try { localStorage.setItem(k, JSON.stringify(v)); return true; } catch { return false; } },
   del(k) { try { localStorage.removeItem(k); } catch {} },
 };
 


### PR DESCRIPTION
## Summary

- `LS.set` now returns `true` on success and `false` on any error (including `QuotaExceededError`)
- `chat.js` `onDone` handler checks the return value and shows a persistent warning toast when `ff_msgs` cannot be persisted

## Root Cause

`LS.set` swallowed all localStorage errors with an empty `catch {}`. When quota was exceeded during a long conversation, the entire message history silently failed to save. Users would lose history on the next page load with no explanation. This fix was previously implemented in PR #73 but was inadvertently overwritten by later commits on the chore-issue-54 branch.

## Scoped Changes

- `freeforge/src/state.js` — `LS.set` returns `true`/`false` instead of `void`
- `freeforge/src/features/chat.js` — `onDone` checks `LS.set` return and shows a warning toast

## Tests and Results

```
node --test tests/security/*.test.mjs
# tests 19 / pass 19 / fail 0
```

## Risk

Low — `LS.set` return value was previously unused; all existing callers that ignore the return continue to work as before. Only the `ff_msgs` persistence call shows the warning.

## Rollback

Revert commit `3e2b640`. No data migration required.

## Dependencies

None.

Closes #36