### PR TITLE
fix(security): remove window.__freeforgeGetErrorLog global debug accessor

### DIFF
--- a/freeforge/src/app.js
+++ b/freeforge/src/app.js
@@ -3,7 +3,7 @@ import { loadModels } from './features/models.js';
 import { hideObError, validateAndConnect } from './features/onboarding.js';
 import { closePalette, openPalette } from './features/palette.js';
 import { clearKey, clearKeyError as clearSettingsKeyError, closeSettings, openSettings, updateKey } from './features/settings.js';
-import { $, getErrorLog, getStoredKey, LS, recordError, S } from './state.js';
+import { $, getStoredKey, LS, recordError, S } from './state.js';
 import { renderCtxPill } from './ui/ctx-pill.js';
 import { renderAllMessages, scrollBottom } from './ui/messages.js';
 import { hideInvalidBanner, showScreen } from './ui/screen.js';
@@ -51,8 +51,6 @@ function installErrorCapture() {
     });
   });
 
-  // Local-only inspection hook for debugging without external telemetry.
-  window.__freeforgeGetErrorLog = getErrorLog;
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary

- Removes `window.__freeforgeGetErrorLog = getErrorLog` assignment from `app.js`
- Removes the now-unused `getErrorLog` import

## Root Cause

The global property was added as a debug convenience, but it exposes internal error log entries (file paths, stack fragments) to any same-origin JavaScript — including browser extensions at page level or XSS payloads. No build step exists to strip it in production.

Error capture via `recordError` is preserved; only the global accessor is removed.

## Scoped Changes

- `freeforge/src/app.js` — removed 2 lines (comment + assignment), removed `getErrorLog` from import

## Tests and Results

```
grep -n '__freeforgeGetErrorLog' freeforge/src/app.js
# (no output — property removed)

node --test tests/security/*.test.mjs
# tests 19 / pass 19 / fail 0
```

## Risk

Low — removing a global debug hook. Any console/extension code calling `window.__freeforgeGetErrorLog()` will receive `undefined`, but no production code path calls it.

## Rollback

Revert commit `d0c200d`. No data migration required.

## Dependencies

None.

Closes #91