### PR TITLE
fix(ux): reject API keys that do not match 'sk-or-v1-' prefix before network call

### DIFF
--- a/freeforge/src/features/onboarding.js
+++ b/freeforge/src/features/onboarding.js
@@ -8,6 +8,7 @@ import { populateModelsFromState } from './models.js';
 export async function validateAndConnect(key) {
   key = key.trim();
   if (!key) { showObError('Enter your API key first'); return; }
+  if (!key.startsWith('sk-or-v1-')) { showObError("Keys must start with 'sk-or-v1-'"); return; }
 
   $('ob-save-label').classList.add('hidden');
   $('ob-save-loading').classList.remove('hidden');

--- a/freeforge/src/features/settings.js
+++ b/freeforge/src/features/settings.js
@@ -95,6 +95,10 @@ export async function updateKey() {
     showKeyError('Enter a key');
     return;
   }
+  if (!key.startsWith('sk-or-v1-')) {
+    showKeyError("Keys must start with 'sk-or-v1-'");
+    return;
+  }
   const btn = $('settings-update-btn');
   btn.textContent = 'Validating…';
   btn.disabled = true;


### PR DESCRIPTION
## Summary

- Adds a local `startsWith('sk-or-v1-')` format check in both `validateAndConnect` (onboarding) and `updateKey` (settings) before any network request is made
- Malformed keys receive an immediate, specific error message without a network round-trip

## Root Cause

Both key-entry paths performed only an empty-string check before calling `fetchFreeModels`. Users who paste clipboard junk or keys from other providers triggered an unnecessary network request before receiving an error.

## Scoped Changes

- `freeforge/src/features/onboarding.js` — 1 line added after empty-string check
- `freeforge/src/features/settings.js` — 3 lines added after empty-string check

## Tests and Results

```
grep -n 'sk-or-v1' freeforge/src/features/onboarding.js freeforge/src/features/settings.js
# → onboarding.js:11 and settings.js:98

node --test tests/security/*.test.mjs
# tests 19 / pass 19 / fail 0
```

## Risk

Low — UX improvement only; server-side validation remains authoritative. A key matching the prefix but otherwise invalid still gets rejected by the API.

## Rollback

Revert commit `d18858b`. No data migration required.

## Dependencies

None.

Closes #92