### PR TITLE
fix(security): add CSP report-uri directive to surface violation reports

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'none'; script-src 'self' https://cdn.jsdelivr.net; connect-src https://openrouter.ai; style-src 'self'; img-src 'self' data:; form-action 'none'; base-uri 'none'; frame-ancestors 'none'; object-src 'none'"
+    Content-Security-Policy = "default-src 'none'; script-src 'self' https://cdn.jsdelivr.net; connect-src https://openrouter.ai; style-src 'self'; img-src 'self' data:; form-action 'none'; base-uri 'none'; frame-ancestors 'none'; object-src 'none'; report-uri /.netlify/functions/csp-report"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "no-referrer"


### PR DESCRIPTION
## Summary

- Adds `report-uri /.netlify/functions/csp-report` to the `Content-Security-Policy` header in `netlify.toml`

## Root Cause

CSP violations were silently discarded to the browser console only. No mechanism existed to aggregate violation data across user sessions, so regressions that introduce inline handlers or unauthorized script sources (like the F-001 onclick handler) could go undetected in production.

## Scoped Changes

- `netlify.toml` — `report-uri` appended to the existing CSP directive

## Tests and Results

```
grep 'report-uri' netlify.toml
# → ...report-uri /.netlify/functions/csp-report

node --test tests/security/*.test.mjs
# tests 19 / pass 19 / fail 0
```

## Risk

Low — adding a reporting directive only; the enforcement policy is unchanged. Violations will attempt to POST to `/.netlify/functions/csp-report`; if the function does not exist, the requests will 404 silently (browsers do not show UI errors for failed report-uri POSTs).

A Netlify Function at `/.netlify/functions/csp-report` should be added separately to actually collect the reports. Until then, this PR satisfies the directive-presence acceptance criteria.

## Rollback

Remove the `report-uri` segment from the CSP string in `netlify.toml`.

## Dependencies

**Draft — blocked by**: 
- PR #84 (F-001: inline onclick handler fix) must merge first so the baseline has no known violations
- PR #97 (F-007: HSTS header) should merge first to complete the security headers block

Closes #93