### PR TITLE
test(api): add regression tests for all api.js HTTP error paths and abort behavior

### DIFF
--- a/tests/security/api-error-paths.test.mjs
+++ b/tests/security/api-error-paths.test.mjs
@@ -1,0 +1,77 @@
+/**
+ * Regression tests for api.js error handling paths.
+ * Uses static source inspection to avoid DOM dependency in the test runner.
+ * Each test asserts that the relevant branch exists with the expected message,
+ * catching regressions where error handlers are removed or silenced.
+ */
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+async function read(relPath) {
+  return readFile(path.resolve(relPath), 'utf8');
+}
+
+// ── fetchFreeModels error branches ──────────────────────────────────────────
+
+test('fetchFreeModels throws on HTTP 401 with "Invalid API key"', async () => {
+  const src = await read('freeforge/src/api.js');
+  assert.match(src, /res\.status === 401[\s\S]*?throw new Error\('Invalid API key'\)/);
+});
+
+test('fetchFreeModels throws on HTTP 429 with rate-limit message', async () => {
+  const src = await read('freeforge/src/api.js');
+  assert.match(src, /res\.status === 429[\s\S]*?throw new Error\('Rate limited/);
+});
+
+test('fetchFreeModels throws on other non-ok status with status code in message', async () => {
+  const src = await read('freeforge/src/api.js');
+  assert.match(src, /throw new Error\(`Failed to fetch models \(\$\{res\.status\}\)`\)/);
+});
+
+// ── streamCompletion pre-connection error branches ───────────────────────────
+
+test('streamCompletion calls onDone on AbortError before connection is established', async () => {
+  const src = await read('freeforge/src/api.js');
+  assert.match(src, /e\.name === 'AbortError'[\s\S]*?return onDone\('\{\}', ''\)/);
+});
+
+test('streamCompletion calls onError with network message on non-abort pre-connection failure', async () => {
+  const src = await read('freeforge/src/api.js');
+  assert.match(src, /onError\('Network error — check your connection\.'\)/);
+});
+
+// ── streamCompletion HTTP error branches ─────────────────────────────────────
+
+test('streamCompletion calls showInvalidBanner and onError on HTTP 401', async () => {
+  const src = await read('freeforge/src/api.js');
+  assert.match(src, /res\.status === 401[\s\S]*?showInvalidBanner\(\)[\s\S]*?onError\('Invalid API key/);
+});
+
+test('streamCompletion calls onError on HTTP 429 with rate-limit message', async () => {
+  const src = await read('freeforge/src/api.js');
+  assert.match(src, /res\.status === 429[\s\S]*?onError\('Rate limited — try again in a moment\.'\)/);
+});
+
+test('streamCompletion calls onError on HTTP 400 with bad-request prefix', async () => {
+  const src = await read('freeforge/src/api.js');
+  assert.match(src, /res\.status === 400[\s\S]*?onError\(`Bad request:/);
+});
+
+test('streamCompletion calls onError on HTTP 413 with context-too-long message', async () => {
+  const src = await read('freeforge/src/api.js');
+  assert.match(src, /res\.status === 413[\s\S]*?onError\('Context too long — start a new chat\.'\)/);
+});
+
+// ── streamCompletion mid-stream abort ────────────────────────────────────────
+
+test('streamCompletion calls onDone with accumulated content on mid-stream AbortError', async () => {
+  const src = await read('freeforge/src/api.js');
+  assert.match(src, /e\.name === 'AbortError'[\s\S]*?return onDone\(donePayload, full\)/);
+});
+
+test('streamCompletion calls onError on non-abort mid-stream error', async () => {
+  const src = await read('freeforge/src/api.js');
+  assert.match(src, /onError\('Stream interrupted\.'\)/);
+});


### PR DESCRIPTION
## Summary

- Adds `tests/security/api-error-paths.test.mjs` with 11 regression tests covering every error code branch in `fetchFreeModels` and `streamCompletion` plus both abort paths

## Root Cause

The test suite covered XSS, storage, and markdown risks but had no tests for `api.js` error handling. Regressions that silently removed the 401 banner, changed error messages, or dropped abort handling would pass CI undetected.

## Scoped Changes

- `tests/security/api-error-paths.test.mjs` — new file, 77 lines
- No production code changed

## Tests and Results

```
node --test tests/security/*.test.mjs
# tests 30 (19 existing + 11 new) / pass 30 / fail 0
```

Covered paths:
- `fetchFreeModels`: HTTP 401 (Invalid API key), 429 (rate limit), other non-ok status
- `streamCompletion` pre-connection: AbortError → `onDone('{}', '')`, non-abort → `onError('Network error…')`
- `streamCompletion` HTTP errors: 401 + `showInvalidBanner`, 429, 400, 413
- `streamCompletion` mid-stream: AbortError → `onDone(donePayload, full)`, non-abort → `onError('Stream interrupted.')`

## Risk

None — test-only change.

## Rollback

Delete `tests/security/api-error-paths.test.mjs`.

## Dependencies

None. (Tests cover the current `origin/main` API implementation as-is.)

Closes #94