### PR TITLE
[F-001] Context token counter accumulates total_tokens across turns instead of tracking current window fill

### DIFF
--- a/freeforge/src/features/chat.js
+++ b/freeforge/src/features/chat.js
@@ -65,11 +65,11 @@ export async function sendMessage(text) {
       try { parsed = JSON.parse(rawPayload); } catch { parsed = {}; }
       const exactTokens = parsed?.usage?.total_tokens ?? null;
       if (exactTokens !== null) {
-        S.contextTokens += exactTokens;
+        S.contextTokens = exactTokens;
         S.usageIsExact = true;
       } else {
         const charEstimate = Math.ceil((text.length + S.lastAssistantResponse.length) / 4);
-        S.contextTokens += charEstimate;
+        S.contextTokens = charEstimate;
         S.usageIsExact = false;
       }
       if (!Number.isFinite(S.contextTokens) || S.contextTokens < 0) S.contextTokens = 0;

--- a/tests/security/chat-context-tokens.test.mjs
+++ b/tests/security/chat-context-tokens.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+async function read(relPath) {
+  return readFile(path.resolve(relPath), 'utf8');
+}
+
+test('chat.js replaces context token totals instead of accumulating them', async () => {
+  const source = await read('freeforge/src/features/chat.js');
+
+  assert.match(source, /S\.contextTokens = exactTokens;/);
+  assert.match(source, /S\.contextTokens = charEstimate;/);
+  assert.doesNotMatch(source, /S\.contextTokens \+= exactTokens;/);
+  assert.doesNotMatch(source, /S\.contextTokens \+= charEstimate;/);
+});


### PR DESCRIPTION
## Summary
Replace context token accumulation with the latest turn's total and add a regression check.

## Root Cause
`usage.total_tokens` already reflects the full conversation for a turn. Adding it into `S.contextTokens` double-counted earlier turns, and the char-estimate fallback had the same bug.

## Scoped Changes
- `freeforge/src/features/chat.js`: replace `+=` with `=` for exact and estimated context tokens.
- `tests/security/chat-context-tokens.test.mjs`: source-level regression test that fails if accumulation returns.

## Tests and Results
- `node --test tests/security/*.test.mjs` -> 31 tests passed, 0 failed.

## Risk
Low. This only changes context-pill accounting.

## Rollback
Revert commit `b677e82`.

## Dependencies
None. The audit noted an overlap with F-002, but the fix is independent.

## Screenshots / Evidence
Not applicable.

Closes #103
