### PR TITLE
[F-002] OpenRouter streaming requests omit stream_options: {include_usage: true}, preventing exact token counts

### DIFF
--- a/freeforge/src/api.js
+++ b/freeforge/src/api.js
@@ -33,7 +33,7 @@ export async function streamCompletion(msgs, modelId, key, { onToken, onDone, on
         'Authorization': `Bearer ${key}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ model: modelId, messages: msgs, stream: true }),
+      body: JSON.stringify({ model: modelId, messages: msgs, stream: true, stream_options: { include_usage: true } }),
       signal,
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
Opt OpenRouter streaming requests into usage reporting so completed responses can carry exact token counts.

## Root Cause
The streaming body omitted `stream_options: { include_usage: true }`, so OpenRouter-compatible streams had no usage payload to surface.

## Scoped Changes
- `freeforge/src/api.js`: add `stream_options: { include_usage: true }` to the streaming request body.

## Tests and Results
- `node --test tests/security/*.test.mjs` -> 30 tests passed, 0 failed.

## Risk
Very low. The change is additive and limited to the request payload.

## Rollback
Revert commit `b9b305b`.

## Dependencies
None. The audit noted overlap with F-001, but this change is independent.

## Screenshots / Evidence
Not applicable.

Closes #104
