### PR TITLE
[F-003] Command palette does not save or restore focus on close, violating WCAG 2.1 SC 2.4.3

### DIFF
--- a/freeforge/src/features/palette.js
+++ b/freeforge/src/features/palette.js
@@ -13,6 +13,7 @@ const BASE_ACTIONS = [
 
 let activeIndex = 0;
 let filteredActions = [];
+let previousFocus = null;
 
 function buildActions() {
   const modelActions = (S.models ?? []).map(m => ({
@@ -52,6 +53,7 @@ function render(query = '') {
 
 export function openPalette() {
   activeIndex = 0;
+  previousFocus = document.activeElement;
   const palette = document.getElementById('cmd-palette');
   const input = document.getElementById('cmd-search');
   if (!palette || !input) return;
@@ -63,6 +65,8 @@ export function openPalette() {
 
 export function closePalette() {
   document.getElementById('cmd-palette')?.classList.add('hidden');
+  if (previousFocus && document.contains(previousFocus)) previousFocus.focus();
+  previousFocus = null;
 }
 
 document.getElementById('cmd-search')?.addEventListener('input', e => {


### PR DESCRIPTION
## Summary
Restore command-palette focus to the element that opened it.

## Root Cause
`openPalette()` moved focus into the palette but never remembered the previously focused element, so `closePalette()` had nothing to restore.

## Scoped Changes
- `freeforge/src/features/palette.js`: save `document.activeElement` on open and restore it on close using the same pattern already used by settings.

## Tests and Results
- `node --test tests/security/*.test.mjs` -> 30 tests passed, 0 failed.

## Risk
Low. This only affects focus restoration when the palette closes.

## Rollback
Revert commit `11a4e4c`.

## Dependencies
None.

## Screenshots / Evidence
Not applicable.

Closes #105
