### PR TITLE
[F-004] Stream reader not explicitly cancelled on non-AbortError, leaving response body stream open

### DIFF
--- a/freeforge/src/api.js
+++ b/freeforge/src/api.js
@@ -79,6 +79,7 @@ export async function streamCompletion(msgs, modelId, key, { onToken, onDone, on
     }
   } catch (e) {
     if (e.name === 'AbortError') return onDone(donePayload, full);
+    try { reader.cancel(); } catch {}
     onError('Stream interrupted.');
     return;
   }


### PR DESCRIPTION
## Summary
Close the reader when a stream fails unexpectedly so the underlying response body is not left open.

## Root Cause
The non-AbortError catch path surfaced the interruption without explicitly cancelling the `ReadableStreamDefaultReader`.

## Scoped Changes
- `freeforge/src/api.js`: call `reader.cancel()` in the non-AbortError catch block, wrapped in a local `try/catch`.

## Tests and Results
- `node --test tests/security/*.test.mjs` -> 30 tests passed, 0 failed.

## Risk
Very low. The change only touches the unexpected-error path.

## Rollback
Revert commit `b825e1a`.

## Dependencies
None.

## Screenshots / Evidence
Not applicable.

Closes #106
