### PR TITLE
[F-005] window.newChat redundant global assignment in chat.js expands attack surface

### DIFF
--- a/freeforge/src/features/chat.js
+++ b/freeforge/src/features/chat.js
@@ -142,5 +142,3 @@ export function newChat() {
   renderAllMessages();
   renderCtxPill();
 }
-
-if (typeof window !== 'undefined') window.newChat = newChat;


### PR DESCRIPTION
## Summary
Remove the redundant `window.newChat` global and keep the delegated action path as the only entry point.

## Root Cause
`window.newChat` was a leftover from the inline-handler era and no longer served any code path in the app.

## Scoped Changes
- `freeforge/src/features/chat.js`: delete the dead global assignment.

## Tests and Results
- `node --test tests/security/*.test.mjs` -> 30 tests passed, 0 failed.

## Risk
Very low. The UI already calls `newChat()` through imports and delegated clicks.

## Rollback
Revert commit `82074fe`.

## Dependencies
None.

## Screenshots / Evidence
Not applicable.

Closes #107
