### PR TITLE
[F-006] CI branch filter patterns use chore-issue-* (hyphen) but repository uses chore/issue-* (slash) naming

### DIFF
--- a/.github/workflows/biome-check.yml
+++ b/.github/workflows/biome-check.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-      - 'fix-issue-*'
-      - 'test-issue-*'
-      - 'chore-issue-*'
+      - 'fix/issue-*'
+      - 'test/issue-*'
+      - 'chore/issue-*'
   pull_request:
 
 jobs:

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-      - 'test-issue-*'
-      - 'fix-issue-*'
-      - 'chore-issue-*'
+      - 'test/issue-*'
+      - 'fix/issue-*'
+      - 'chore/issue-*'
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
Make the push-event branch filters match the repo's slash-based issue branch naming.

## Root Cause
The workflow globs used `chore-issue-*` / `fix-issue-*` / `test-issue-*`, which do not match the actual `chore/issue-*` / `fix/issue-*` / `test/issue-*` branches.

## Scoped Changes
- `.github/workflows/node-tests.yml`: update push branch filters to slash-based patterns.
- `.github/workflows/biome-check.yml`: update push branch filters to slash-based patterns.

## Tests and Results
- `node --test tests/security/*.test.mjs` -> 30 tests passed, 0 failed.
- `git diff --check` -> clean.
- `Select-String` confirmed the updated `chore/issue-*`, `fix/issue-*`, and `test/issue-*` patterns are present.

## Risk
Very low. This only changes when CI runs, not what it runs.

## Rollback
Revert commit `247c1bb`.

## Dependencies
None.

## Screenshots / Evidence
Not applicable.

Closes #108
