### PR TITLE
[F-007] Biome version not pinned in CI, allowing silent linting behavior drift

### DIFF
--- a/.github/workflows/biome-check.yml
+++ b/.github/workflows/biome-check.yml
@@ -22,4 +22,4 @@ jobs:
           node-version: '22'
 
       - name: Run zero-install Biome lint pass
-        run: npx --yes @biomejs/biome check freeforge/src tests/security
+        run: npx --yes @biomejs/biome@1.9.4 check freeforge/src tests/security


### PR DESCRIPTION
## Summary
Pin the Biome binary used in CI to the version aligned with `biome.json`.

## Root Cause
`npx --yes @biomejs/biome` resolves the latest published version at run time, so CI behavior could drift without any repository change.

## Scoped Changes
- `.github/workflows/biome-check.yml`: pin the command to `@biomejs/biome@1.9.4`.

## Tests and Results
- `node --test tests/security/*.test.mjs` -> 30 tests passed, 0 failed.
- `git diff --check` -> clean.
- `Select-String` confirmed `@biomejs/biome@1.9.4` is present in the workflow.

## Risk
Very low. The change only makes CI deterministic.

## Rollback
Revert commit `5792ec6`.

## Dependencies
None.

## Screenshots / Evidence
Not applicable.

Closes #109
