### PR TITLE
[F-008] No LICENSE file present; code is all rights reserved by default

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JackSmack1971
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
Add an explicit MIT license so the repository is legally reusable as intended.

## Root Cause
The repository had no root LICENSE file, so the code defaulted to all-rights-reserved.

## Scoped Changes
- `LICENSE`: add a standard MIT license file at the repository root.

## Tests and Results
- `Get-ChildItem LICENSE*` -> `LICENSE` present.
- `git diff --check` -> clean.

## Risk
None to runtime behavior. This only changes repository licensing metadata.

## Rollback
Delete `LICENSE` (or revert commit `84b2425`).

## Dependencies
None.

## Screenshots / Evidence
Not applicable.

Closes #110
