### PR TITLE
fix(csp): remove dangling report-uri pointing to non-existent Netlify function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'none'; script-src 'self' https://cdn.jsdelivr.net; connect-src https://openrouter.ai; style-src 'self'; img-src 'self' data:; form-action 'none'; base-uri 'none'; frame-ancestors 'none'; object-src 'none'; report-uri /.netlify/functions/csp-report"
+    Content-Security-Policy = "default-src 'none'; script-src 'self' https://cdn.jsdelivr.net; connect-src https://openrouter.ai; style-src 'self'; img-src 'self' data:; form-action 'none'; base-uri 'none'; frame-ancestors 'none'; object-src 'none'"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "no-referrer"


### PR DESCRIPTION
## Summary

- Removes `report-uri /.netlify/functions/csp-report` from the CSP header in `netlify.toml`
- The referenced Netlify function does not exist; all CSP violation reports were silently discarded (browsers received a 404 on POST)

## Root Cause

The `report-uri` directive was added to the CSP header (commit 6e39573) without implementing the corresponding Netlify function. No `netlify/functions/` directory exists in the repository.

## Scoped Changes

| File | Change |
|------|--------|
| `netlify.toml` | Remove ` report-uri /.netlify/functions/csp-report` from CSP header value |

## Tests and Results

```
node --test tests/security/style-csp.test.mjs
# pass 3
# fail 0
```

All 3 `style-csp` tests pass. No test previously asserted the presence of `report-uri`, so no test updates required.

## Risk

**Very Low.** Removing a directive that pointed to a non-existent endpoint. The CSP policy itself (all source allowlists) is unchanged. CSP violation reporting moves from silently-dropped-404 to not-sent, which has no impact on the application's security posture since no reports were being received.

## Rollback

Revert this commit. The `report-uri` line is a single-line edit and is fully reversible.

## Dependencies

None. This fix is independent of F-003 and F-004.

## Audit Reference

Audit run `20260628T111341Z`, finding `F-002`. Verified at SHA `abe89c250b0af9fea4d9c2e38b93b8e8925a427f` and confirmed still present at `002c05814398f84e8fb13d460452b01fb432fb4c`.

Closes #120