### PR TITLE
fix(markdown): guard marked.use() against CDN failure at module scope

### DIFF
--- a/freeforge/src/markdown.js
+++ b/freeforge/src/markdown.js
@@ -2,7 +2,7 @@ import { esc } from './state.js';
 
 // Module-level initialization (SEC-07): call once at module load, not per-render.
 // marked.use() must not be called inside a function or loop per marked.js docs.
-marked.use({ breaks: true, gfm: true });
+if (typeof marked !== 'undefined') marked.use({ breaks: true, gfm: true });
 
 // Explicit allowlist prevents CSS injection (style=) and blocks tags outside
 // the markdown rendering surface area. Keep attributes narrow so untrusted
@@ -31,6 +31,7 @@ if (typeof DOMPurify !== 'undefined') {
 
 export function renderMd(text) {
   if (!text) return '';
+  if (typeof marked === 'undefined') return esc(text).replace(/\n/g, '<br>');
   try {
     const raw = marked.parse(text);
     // Sanitize LLM-generated HTML before injecting into the DOM.

--- a/tests/security/markdown-pipeline.test.mjs
+++ b/tests/security/markdown-pipeline.test.mjs
@@ -5,23 +5,27 @@ import test from 'node:test';
 
 const ESC_IMPL = "const esc = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\\\"/g, '&quot;');";
 
-async function loadMarkdownModule({ parseImpl, sanitizeImpl } = {}) {
+async function loadMarkdownModule({ parseImpl, sanitizeImpl, markedAvailable = true } = {}) {
   const filePath = path.resolve('freeforge/src/markdown.js');
   const source = await readFile(filePath, 'utf8');
   const transformed = source.replace("import { esc } from './state.js';", ESC_IMPL);
 
-  globalThis.marked = {
-    useCalls: [],
-    parseCalls: [],
-    use(options) {
-      this.useCalls.push(options);
-    },
-    parse(text) {
-      this.parseCalls.push(text);
-      if (parseImpl) return parseImpl(text);
-      return `<p>${text}</p>`;
-    },
-  };
+  if (markedAvailable) {
+    globalThis.marked = {
+      useCalls: [],
+      parseCalls: [],
+      use(options) {
+        this.useCalls.push(options);
+      },
+      parse(text) {
+        this.parseCalls.push(text);
+        if (parseImpl) return parseImpl(text);
+        return `<p>${text}</p>`;
+      },
+    };
+  } else {
+    globalThis.marked = undefined;
+  }
 
   if (sanitizeImpl) {
     globalThis.DOMPurify = {
@@ -103,4 +107,19 @@ test('renderMd falls back to escaped plaintext when marked.parse throws', async 
 
   assert.equal(output, '&lt;b&gt;unsafe&lt;/b&gt;');
   assert.equal(globalThis.DOMPurify.calls.length, 0);
+});
+
+test('markdown.js module initializes without throwing when marked CDN is unavailable', async () => {
+  await assert.doesNotReject(
+    () => loadMarkdownModule({ markedAvailable: false }),
+    'markdown.js must not throw ReferenceError when marked is undefined',
+  );
+});
+
+test('renderMd returns escaped plaintext when marked CDN is unavailable', async () => {
+  const { renderMd } = await loadMarkdownModule({ markedAvailable: false });
+
+  const output = renderMd('<b>hello</b>\nworld');
+
+  assert.equal(output, '&lt;b&gt;hello&lt;/b&gt;<br>world');
 });


### PR DESCRIPTION
## Summary

- Wraps the module-scope `marked.use()` call in a `typeof marked !== 'undefined'` guard, matching the existing DOMPurify pattern
- Adds an early return in `renderMd()` that returns escaped plain text when `marked` is unavailable, so callers never hit an unguarded `marked.parse()` call
- Adds 2 regression tests: module initializes without throwing, and `renderMd()` returns safe fallback text, both when marked CDN is absent

## Root Cause

`marked.use({ breaks: true, gfm: true })` was called unconditionally at module scope. If the marked CDN fails to load (network error, SRI mismatch, browser content-blocking), the JavaScript engine throws `ReferenceError: marked is not defined` during module evaluation. This cascades: `markdown.js` fails to initialize, which propagates to `messages.js` and `app.js`, leaving the user with a blank or non-functional page. The DOMPurify section in the same file already used the correct `typeof` guard pattern.

## Scoped Changes

| File | Change |
|------|--------|
| `freeforge/src/markdown.js` | Wrap `marked.use()` in `typeof` guard; add early return in `renderMd()` for absent marked |
| `tests/security/markdown-pipeline.test.mjs` | Add `markedAvailable` option to helper; add 2 regression tests |

## Tests and Results

```
node --test tests/security/markdown-pipeline.test.mjs
# pass 6
# fail 0
```

4 pre-existing tests still pass. 2 new tests verify the CDN-failure path.

```
npx @biomejs/biome@1.9.4 check freeforge/src/markdown.js
Checked 1 file in 3ms. No fixes applied.
```

## Risk

**Low.** The guard is a purely additive safety check. When `marked` is available (the normal path), behavior is identical. The fallback path (escaped text) existed before this change in the `renderMd` catch block; this PR makes it reachable before entering `try` rather than after a thrown `ReferenceError`.

## Rollback

Revert this commit. The change is a two-line guard addition and is fully reversible.

## Dependencies

None. This fix is independent of F-002 and F-004.

## Audit Reference

Audit run `20260628T111341Z`, finding `F-003`. Verified at SHA `abe89c250b0af9fea4d9c2e38b93b8e8925a427f` and confirmed still present at `002c05814398f84e8fb13d460452b01fb432fb4c`.

Closes #121