### PR TITLE
fix(chat): compute context token estimate from full message history

### DIFF
--- a/freeforge/src/features/chat.js
+++ b/freeforge/src/features/chat.js
@@ -68,8 +68,8 @@ export async function sendMessage(text) {
         S.contextTokens = exactTokens;
         S.usageIsExact = true;
       } else {
-        const charEstimate = Math.ceil((trimmedText.length + S.lastAssistantResponse.length) / 4);
-        S.contextTokens = charEstimate;
+        const totalChars = S.messages.filter(m => m.role === 'user' || m.role === 'assistant').reduce((sum, m) => sum + (m.content?.length ?? 0), 0);
+        S.contextTokens = Math.ceil(totalChars / 4);
         S.usageIsExact = false;
       }
       if (!Number.isFinite(S.contextTokens) || S.contextTokens < 0) S.contextTokens = 0;

--- a/tests/security/chat-context-tokens.test.mjs
+++ b/tests/security/chat-context-tokens.test.mjs
@@ -11,7 +11,13 @@ test('chat.js replaces context token totals instead of accumulating them', async
   const source = await read('freeforge/src/features/chat.js');
 
   assert.match(source, /S\.contextTokens = exactTokens;/);
-  assert.match(source, /S\.contextTokens = charEstimate;/);
   assert.doesNotMatch(source, /S\.contextTokens \+= exactTokens;/);
-  assert.doesNotMatch(source, /S\.contextTokens \+= charEstimate;/);
+});
+
+test('chat.js estimate path sums all messages rather than only the current turn', async () => {
+  const source = await read('freeforge/src/features/chat.js');
+
+  assert.match(source, /S\.messages\.filter/, 'estimate must iterate over S.messages');
+  assert.match(source, /S\.contextTokens = Math\.ceil\(totalChars \/ 4\);/);
+  assert.doesNotMatch(source, /S\.contextTokens = charEstimate;/, 'single-turn estimate variable must be removed');
 });


### PR DESCRIPTION
## Summary

- Replaces the single-turn character estimate (`trimmedText.length + lastAssistantResponse.length`) with a sum over the full `S.messages` array
- Updates the regression test to assert the new summing behavior and remove the stale `charEstimate` assertion

## Root Cause

When a model does not return `usage.total_tokens` in the SSE stream (`exactTokens === null`), `S.contextTokens` was set to only the current turn's character count divided by 4. After a prior fix replaced `+=` with `=` to prevent double-counting in the exact-token branch, the estimate branch was left covering only the current user message plus the current assistant response — not the full conversation history that is actually sent to the API. The result: after multiple turns, the context pill showed a percentage that effectively reset to near zero each turn.

## Scoped Changes

| File | Change |
|------|--------|
| `freeforge/src/features/chat.js` | Replace 2-operand char estimate with `S.messages` reduce sum; remove `charEstimate` variable |
| `tests/security/chat-context-tokens.test.mjs` | Remove stale `charEstimate` assertion; add test asserting full-history summing |

## Tests and Results

```
node --test tests/security/chat-context-tokens.test.mjs
# pass 2
# fail 0
```

```
npx @biomejs/biome@1.9.4 check freeforge/src/features/chat.js
Checked 1 file in 6ms. No fixes applied.
```

## Risk

**Low.** The exact-token branch (`exactTokens !== null`) is unchanged. The change only affects the fallback estimate path. The new estimate will be larger than the old one (as intended), so the context pill will move toward 100% sooner, which is the correct behavior and was the stated user-visible bug.

## Rollback

Revert this commit. The change is a 2-line replacement and is fully reversible.

## Dependencies

None. This fix is independent of F-002 and F-003.

## Audit Reference

Audit run `20260628T111341Z`, finding `F-004`. Verified at SHA `abe89c250b0af9fea4d9c2e38b93b8e8925a427f` and confirmed still present at `002c05814398f84e8fb13d460452b01fb432fb4c`.

Closes #122