### PR TITLE
[F-002] injectCodeBlockUI exits entire function on first processed pre element instead of continuing the loop

### DIFF
--- a/freeforge/src/ui/messages.js
+++ b/freeforge/src/ui/messages.js
@@ -7,7 +7,7 @@ let renderedCount = 0;
 function injectCodeBlockUI(container) {
   for (const pre of container.querySelectorAll('pre')) {
     const codeEl = pre.querySelector('code');
-    if (!codeEl || pre.querySelector('.copy-code-btn')) return;
+    if (!codeEl || pre.querySelector('.copy-code-btn')) continue;
     const langClass = [...codeEl.classList].find(c => c.startsWith('language-'));
     const lang = langClass ? langClass.replace('language-', '') : '';
 

--- a/tests/security/messages-code-blocks.test.mjs
+++ b/tests/security/messages-code-blocks.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+test('messages.js keeps scanning after an already-decorated code block', async () => {
+  const source = await readFile(path.resolve('freeforge/src/ui/messages.js'), 'utf8');
+
+  assert.match(source, /if \(!codeEl \|\| pre\.querySelector\('\.copy-code-btn'\)\) continue;/);
+  assert.doesNotMatch(source, /if \(!codeEl \|\| pre\.querySelector\('\.copy-code-btn'\)\) return;/);
+});


### PR DESCRIPTION
## Summary
Changed the code-block injector guard so later `<pre>` blocks are still processed when one block is already decorated.

## Root Cause
A per-iteration skip used `return`, which exited the whole function instead of skipping the current `<pre>`.

## Scoped Changes
- `freeforge/src/ui/messages.js`
- `tests/security/messages-code-blocks.test.mjs`

## Tests and Exact Results
`node --test tests/security/messages-code-blocks.test.mjs` -> 1 test passed.

## Risk
Low. This is a one-keyword loop-control fix plus a source-level regression check.

## Rollback
Revert the keyword change and the regression test.

## Dependencies
None.

## Evidence
The regression test asserts `continue` is present and `return` is absent at the guard.

Closes #127