### PR TITLE
[F-004] CI GitHub Actions use floating version tags instead of SHA-pinned references

### DIFF
--- a/.github/workflows/biome-check.yml
+++ b/.github/workflows/biome-check.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
 

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
 


### PR DESCRIPTION
## Summary
Pinned the GitHub Actions usages to fixed commit SHAs in both CI workflows.

## Root Cause
Floating `@v5` tags can drift or be force-pushed upstream, so the workflows now reference immutable SHAs.

## Scoped Changes
- `.github/workflows/biome-check.yml`
- `.github/workflows/node-tests.yml`

## Tests and Exact Results
`rg -n "uses:" .github/workflows | Select-String -NotMatch '@[0-9a-f]{40}'` -> no output.

## Risk
Low. This only hardens the action references without changing workflow behavior.

## Rollback
Restore the floating tags if a future action update needs to be staged first.

## Dependencies
None.

## Evidence
Every `uses:` line now ends in a 40-character SHA.

Closes #129