### PR TITLE
[F-005] package.json lists CDN-loaded libraries as npm dependencies, creating false supply-chain signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ HTML, CSS, and JavaScript files directly.
 - DOMPurify for HTML sanitization
 - Netlify for static deployment and response headers
 
+## Runtime CDN Assets
+
+- `marked@18.0.4` from `https://cdn.jsdelivr.net/npm/marked@18.0.4/lib/marked.umd.js`
+  with `sha384-8RA8Ah4c9upJmKfg5nH01OgjZoQ3mRX+ngrKYWXQYj2dHYxFqYz8POSlii33f0wB`
+- `dompurify@3.4.8` from `https://cdn.jsdelivr.net/npm/dompurify@3.4.8/dist/purify.min.js`
+  with `sha384-jrsBdrv4eDpEYIq32u13DPbvB6tRmqIDnA6UlgFBoexpetaiWi7g/VbfMEL1WVen`
+- `tailwindcss@3` from `https://cdn.tailwindcss.com`
+
 ## Privacy Notes
 
 - API keys are stored in `sessionStorage`, scoped to the current browser tab

--- a/freeforge/package.json
+++ b/freeforge/package.json
@@ -7,11 +7,21 @@
   "scripts": {
     "test": "node --test"
   },
-  "dependencies": {
-    "dompurify": "3.4.8",
-    "marked": "18.0.4"
-  },
-  "devDependencies": {
-    "tailwindcss": "^3.4.0"
+  "_cdnDependencies": {
+    "note": "Runtime libraries are loaded from CDN with SRI and are not npm-installed.",
+    "marked": {
+      "version": "18.0.4",
+      "cdn": "https://cdn.jsdelivr.net/npm/marked@18.0.4/lib/marked.umd.js",
+      "sri": "sha384-8RA8Ah4c9upJmKfg5nH01OgjZoQ3mRX+ngrKYWXQYj2dHYxFqYz8POSlii33f0wB"
+    },
+    "dompurify": {
+      "version": "3.4.8",
+      "cdn": "https://cdn.jsdelivr.net/npm/dompurify@3.4.8/dist/purify.min.js",
+      "sri": "sha384-jrsBdrv4eDpEYIq32u13DPbvB6tRmqIDnA6UlgFBoexpetaiWi7g/VbfMEL1WVen"
+    },
+    "tailwindcss": {
+      "version": "3",
+      "cdn": "https://cdn.tailwindcss.com"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Removed npm-managed dependency entries for CDN-loaded runtime libraries and documented the CDN sources.

## Root Cause
`package.json` listed libraries that are loaded only from the CDN, which created a false supply-chain signal.

## Scoped Changes
- `freeforge/package.json`
- `README.md`

## Tests and Exact Results
`node -e "JSON.parse(require('fs').readFileSync('freeforge/package.json','utf8')); console.log('package.json ok')"` -> `package.json ok`.

## Risk
Very low. This is metadata/documentation only; the runtime loading path is unchanged.

## Rollback
Restore the removed metadata and README section if the repo later adopts npm-managed delivery.

## Dependencies
None.

## Evidence
Runtime CDN versions and SRI hashes are now documented instead of being implied by npm metadata.

Closes #130