### PR TITLE
[F-006] CSP script-src uses host-based cdn.jsdelivr.net allowlist instead of hash-based restriction

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'none'; script-src 'self' https://cdn.jsdelivr.net; connect-src https://openrouter.ai; style-src 'self'; img-src 'self' data:; form-action 'none'; base-uri 'none'; frame-ancestors 'none'; object-src 'none'"
+    Content-Security-Policy = "default-src 'none'; script-src 'self' 'sha384-8RA8Ah4c9upJmKfg5nH01OgjZoQ3mRX+ngrKYWXQYj2dHYxFqYz8POSlii33f0wB' 'sha384-jrsBdrv4eDpEYIq32u13DPbvB6tRmqIDnA6UlgFBoexpetaiWi7g/VbfMEL1WVen'; connect-src https://openrouter.ai; style-src 'self'; img-src 'self' data:; form-action 'none'; base-uri 'none'; frame-ancestors 'none'; object-src 'none'"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "no-referrer"

--- a/tests/security/style-csp.test.mjs
+++ b/tests/security/style-csp.test.mjs
@@ -15,6 +15,13 @@ test('style-src is restricted to self-hosted stylesheets', async () => {
   assert.doesNotMatch(netlify, /style-src [^"]*cdn\.jsdelivr\.net/);
 });
 
+test('script-src is pinned to the two CDN script hashes', async () => {
+  const netlify = await read('netlify.toml');
+
+  assert.match(netlify, /script-src 'self' 'sha384-8RA8Ah4c9upJmKfg5nH01OgjZoQ3mRX\+ngrKYWXQYj2dHYxFqYz8POSlii33f0wB' 'sha384-jrsBdrv4eDpEYIq32u13DPbvB6tRmqIDnA6UlgFBoexpetaiWi7g\/VbfMEL1WVen'/);
+  assert.doesNotMatch(netlify, /script-src [^"]*cdn\.jsdelivr\.net/);
+});
+
 test('index.html uses a local Tailwind stylesheet', async () => {
   const html = await read('freeforge/index.html');
 


### PR DESCRIPTION
## Summary
Replaced the host-based jsDelivr CSP allowlist with the two exact script hashes already used in `index.html`.

## Root Cause
The CSP allowed any script from `cdn.jsdelivr.net` instead of only the known-good CDN assets.

## Scoped Changes
- `netlify.toml`
- `tests/security/style-csp.test.mjs`

## Tests and Exact Results
`node --test tests/security/style-csp.test.mjs` -> 4 tests passed.

## Risk
Low. The change narrows the policy to the exact CDN scripts already loaded by the app.

## Rollback
Restore the host allowlist if a future asset update needs a temporary fallback.

## Dependencies
Related to #128, but implemented independently.

## Evidence
The CSP now contains the two SHA-384 hashes already present on the script tags.

Closes #131