### PR TITLE
[F-007] Settings modal visibility relies on CSS specificity conflict; aria-hidden not toggled on open/close

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -227,7 +227,7 @@
 </div>
 
 <!-- ========== SETTINGS MODAL ========== -->
-<div id="settings-modal" role="dialog" aria-modal="true" aria-labelledby="settings-title" class="fixed inset-0 z-40 hidden items-center justify-center p-4">
+<div id="settings-modal" role="dialog" aria-modal="true" aria-labelledby="settings-title" aria-hidden="true" class="fixed inset-0 z-40 hidden items-center justify-center p-4">
   <div id="settings-backdrop" class="absolute inset-0 modal-bg"></div>
   <div class="surface-card relative w-full max-w-md rounded-2xl border border-zinc-800 p-6 z-10 modal-card">
     <div class="flex items-center justify-between mb-5">

--- a/freeforge/src/features/settings.js
+++ b/freeforge/src/features/settings.js
@@ -33,7 +33,7 @@ function executeClearKey() {
 function getFocusableInModal() {
   return [...$('settings-modal').querySelectorAll(
     'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-  )].filter(el => el.closest('.hidden') === null && el.offsetParent !== null);
+  )].filter(el => el.offsetParent !== null);
 }
 
 export function clearKeyError() {
@@ -73,7 +73,8 @@ export function openSettings() {
   clearKeyError();
   resetClearButton($('settings-clear-btn'));
   const modal = $('settings-modal');
-  modal.classList.add('open');
+  modal.classList.remove('hidden');
+  modal.setAttribute('aria-hidden', 'false');
   modal.addEventListener('keydown', trapFocus);
   const [first] = getFocusableInModal();
   if (first) first.focus();
@@ -83,7 +84,8 @@ export function closeSettings() {
   resetClearButton($('settings-clear-btn'));
   clearKeyError();
   const modal = $('settings-modal');
-  modal.classList.remove('open');
+  modal.classList.add('hidden');
+  modal.setAttribute('aria-hidden', 'true');
   modal.removeEventListener('keydown', trapFocus);
   if (previousFocus && document.contains(previousFocus)) previousFocus.focus();
   previousFocus = null;

--- a/freeforge/styles/app.css
+++ b/freeforge/styles/app.css
@@ -61,7 +61,6 @@ body{background:#09090b;color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFo
 .toast{animation:toastIn .25s ease-out,toastOut .25s ease-in 2.75s forwards}
 @keyframes toastIn{from{transform:translateX(110%);opacity:0}to{transform:translateX(0);opacity:1}}
 @keyframes toastOut{from{opacity:1;transform:translateX(0)}to{opacity:0;transform:translateX(110%)}}
-#settings-modal.open{display:flex}
 .modal-bg{background:rgba(0,0,0,.7);backdrop-filter:blur(4px)}
 .modal-card{animation:slideUp .2s ease-out}
 select{-webkit-appearance:none;appearance:none}

--- a/tests/security/settings-modal.test.mjs
+++ b/tests/security/settings-modal.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+test('settings modal toggles hidden and aria-hidden during open and close', async () => {
+  const js = await readFile(path.resolve('freeforge/src/features/settings.js'), 'utf8');
+  const css = await readFile(path.resolve('freeforge/styles/app.css'), 'utf8');
+  const html = await readFile(path.resolve('freeforge/index.html'), 'utf8');
+
+  assert.match(js, /modal\.classList\.remove\('hidden'\)/);
+  assert.match(js, /modal\.setAttribute\('aria-hidden', 'false'\)/);
+  assert.match(js, /modal\.classList\.add\('hidden'\)/);
+  assert.match(js, /modal\.setAttribute\('aria-hidden', 'true'\)/);
+  assert.doesNotMatch(css, /#settings-modal\.open/);
+  assert.match(html, /id="settings-modal"[^>]*aria-hidden="true"/);
+});


### PR DESCRIPTION
## Summary
Aligned the settings modal with the hidden-class lifecycle and wired `aria-hidden` on open/close.

## Root Cause
The modal relied on an ID+class display override and left hidden descendants in the focusable filter.

## Scoped Changes
- `freeforge/src/features/settings.js`
- `freeforge/styles/app.css`
- `freeforge/index.html`
- `tests/security/settings-modal.test.mjs`

## Tests and Exact Results
`node --test tests/security/settings-modal.test.mjs` -> 1 test passed.

## Risk
Low. The visual behavior stays the same; the state is just driven through the existing hidden class.

## Rollback
Restore the old `open` class rule and hidden filter if needed.

## Dependencies
None.

## Evidence
The regression checks the hidden/aria-hidden lifecycle and removal of `#settings-modal.open`.

Closes #132