### PR TITLE
[F-008] Persistent 'Context nearly full' toast is never dismissed after newChat() or clearKey()

### DIFF
--- a/freeforge/src/features/chat.js
+++ b/freeforge/src/features/chat.js
@@ -2,7 +2,7 @@ import { streamCompletion } from '../api.js';
 import { $, LS, S, uid } from '../state.js';
 import { renderCtxPill } from '../ui/ctx-pill.js';
 import { appendNewMessages, renderAllMessages, replaceMessage, scrollBottom, setStreamMode } from '../ui/messages.js';
-import { toast } from '../ui/toast.js';
+import { clearPersistent, toast } from '../ui/toast.js';
 
 function setLiveRegion(id, text) {
   const region = $(id);
@@ -130,6 +130,7 @@ export function copyLastResponse() {
 
 export function newChat() {
   if (S.abort) { S.abort.abort(); S.abort = null; }
+  clearPersistent();
   S.messages = [];
   S.streaming = false;
   S.contextTokens = 0;

--- a/freeforge/src/features/settings.js
+++ b/freeforge/src/features/settings.js
@@ -1,7 +1,7 @@
 import { fetchFreeModels } from '../api.js';
 import { $, LS, S, clearStoredKey, maskKey, setStoredKey } from '../state.js';
 import { hideInvalidBanner, showScreen } from '../ui/screen.js';
-import { toast } from '../ui/toast.js';
+import { clearPersistent, toast } from '../ui/toast.js';
 import { populateModelsFromState } from './models.js';
 
 const CLEAR_CONFIRM_MS = 3000;
@@ -18,6 +18,7 @@ function resetClearButton(btn) {
 }
 
 function executeClearKey() {
+  clearPersistent();
   clearStoredKey();
   for (const k of ['ff_msgs', 'ff_model']) {
     LS.del(k);

--- a/freeforge/src/ui/toast.js
+++ b/freeforge/src/ui/toast.js
@@ -34,3 +34,7 @@ export function toast(msg, type = 'info', ms = 3000, action = null) {
   $('toasts').appendChild(el);
   if (ms > 0) setTimeout(() => el.remove(), ms + 300);
 }
+
+export function clearPersistent() {
+  $('toasts')?.querySelectorAll('.toast-persistent').forEach(el => el.remove());
+}

--- a/freeforge/src/ui/toast.js
+++ b/freeforge/src/ui/toast.js
@@ -36,5 +36,5 @@ export function toast(msg, type = 'info', ms = 3000, action = null) {
 }
 
 export function clearPersistent() {
-  $('toasts')?.querySelectorAll('.toast-persistent').forEach(el => el.remove());
+  for (const el of $('toasts')?.querySelectorAll('.toast-persistent') ?? []) el.remove();
 }

--- a/tests/security/toast-cleanup.test.mjs
+++ b/tests/security/toast-cleanup.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+test('persistent toasts are cleared by new chat and key reset', async () => {
+  const toastJs = await readFile(path.resolve('freeforge/src/ui/toast.js'), 'utf8');
+  const chatJs = await readFile(path.resolve('freeforge/src/features/chat.js'), 'utf8');
+  const settingsJs = await readFile(path.resolve('freeforge/src/features/settings.js'), 'utf8');
+
+  assert.match(toastJs, /export function clearPersistent\(\)/);
+  assert.match(toastJs, /querySelectorAll\('\.toast-persistent'\)\.forEach\(el => el\.remove\(\)\)/);
+  assert.match(chatJs, /clearPersistent\(\);/);
+  assert.match(settingsJs, /clearPersistent\(\);/);
+});

--- a/tests/security/toast-cleanup.test.mjs
+++ b/tests/security/toast-cleanup.test.mjs
@@ -9,7 +9,7 @@ test('persistent toasts are cleared by new chat and key reset', async () => {
   const settingsJs = await readFile(path.resolve('freeforge/src/features/settings.js'), 'utf8');
 
   assert.match(toastJs, /export function clearPersistent\(\)/);
-  assert.match(toastJs, /querySelectorAll\('\.toast-persistent'\)\.forEach\(el => el\.remove\(\)\)/);
+  assert.match(toastJs, /for \(const el of \$\('toasts'\)\?\.querySelectorAll\('\.toast-persistent'\) \?\? \[\]\) el\.remove\(\);/);
   assert.match(chatJs, /clearPersistent\(\);/);
   assert.match(settingsJs, /clearPersistent\(\);/);
 });


### PR DESCRIPTION
## Summary
Added a `clearPersistent` toast helper and called it from the new-chat and key-reset paths.

## Root Cause
Persistent toasts had no dismissal path, so the context warning could outlive the state it described.

## Scoped Changes
- `freeforge/src/ui/toast.js`
- `freeforge/src/features/chat.js`
- `freeforge/src/features/settings.js`
- `tests/security/toast-cleanup.test.mjs`

## Tests and Exact Results
`node --test tests/security/toast-cleanup.test.mjs` -> 1 test passed.

## Risk
Low. Only `.toast-persistent` elements are removed; timed toasts are unaffected.

## Rollback
Remove the helper and the two call sites.

## Dependencies
None.

## Evidence
The regression checks the helper export and both reset call sites.

Closes #133