### PR TITLE
[F-009] model-select dropdown has no accessible label (WCAG 2.1 SC 1.3.1 / 3.3.2)

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -118,7 +118,7 @@
 
     <div class="flex-1 min-w-0 flex items-center">
       <div class="relative w-full max-w-xs">
-        <select id="model-select" class="w-full text-xs bg-zinc-900 border border-zinc-700 text-zinc-300 rounded-lg pl-3 pr-7 py-2 cursor-pointer hover:border-zinc-600 focus:outline-none focus:border-indigo-500 transition-colors truncate">
+        <select id="model-select" aria-label="Select AI model" class="w-full text-xs bg-zinc-900 border border-zinc-700 text-zinc-300 rounded-lg pl-3 pr-7 py-2 cursor-pointer hover:border-zinc-600 focus:outline-none focus:border-indigo-500 transition-colors truncate">
           <option value="">Loading models…</option>
         </select>
         <div class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">

--- a/tests/security/model-select-label.test.mjs
+++ b/tests/security/model-select-label.test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+test('model-select has a programmatic label', async () => {
+  const html = await readFile(path.resolve('freeforge/index.html'), 'utf8');
+
+  assert.match(html, /<select id="model-select"[^>]*aria-label="Select AI model"/);
+});


### PR DESCRIPTION
## Summary
Added an accessible label to the model selector.

## Root Cause
The select had no programmatic name for assistive technology.

## Scoped Changes
- `freeforge/index.html`
- `tests/security/model-select-label.test.mjs`

## Tests and Exact Results
`node --test tests/security/model-select-label.test.mjs` -> 1 test passed.

## Risk
Very low. This is an attribute-only accessibility fix.

## Rollback
Remove the `aria-label` and the static label test.

## Dependencies
None.

## Evidence
The HTML now exposes `aria-label="Select AI model"` on `#model-select`.

Closes #134