### PR TITLE
[F-010] msg-input textarea has no accessible label (WCAG 2.1 SC 3.3.2)

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -210,7 +210,7 @@
   <div class="surface-strip border-t border-zinc-800 px-4 py-3 flex-shrink-0">
     <div class="max-w-3xl mx-auto">
       <div id="input-box" class="input-shell-surface flex items-end gap-3 rounded-2xl border border-zinc-700 focus-within:border-indigo-500 transition-colors px-4 py-3">
-        <textarea id="msg-input" placeholder="Message FreeForge…" rows="1" maxlength="32000"
+        <textarea id="msg-input" aria-label="Chat message" placeholder="Message FreeForge…" rows="1" maxlength="32000"
                   class="flex-1 bg-transparent text-sm text-zinc-100 placeholder-zinc-400 focus:outline-none leading-relaxed"></textarea>
         <button id="send-btn" aria-label="Send message" class="gradient-btn flex-shrink-0 w-9 h-9 rounded-xl flex items-center justify-center transition-all">
           <svg id="send-icon" class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/tests/security/msg-input-label.test.mjs
+++ b/tests/security/msg-input-label.test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+test('msg-input has a programmatic label', async () => {
+  const html = await readFile(path.resolve('freeforge/index.html'), 'utf8');
+
+  assert.match(html, /<textarea id="msg-input"[^>]*aria-label="Chat message"/);
+});


### PR DESCRIPTION
## Summary
Added an accessible label to the chat input textarea.

## Root Cause
The textarea relied on placeholder text instead of a real label.

## Scoped Changes
- `freeforge/index.html`
- `tests/security/msg-input-label.test.mjs`

## Tests and Exact Results
`node --test tests/security/msg-input-label.test.mjs` -> 1 test passed.

## Risk
Very low. This is an attribute-only accessibility fix.

## Rollback
Remove the `aria-label` and the static label test.

## Dependencies
None.

## Evidence
The HTML now exposes `aria-label="Chat message"` on `#msg-input`.

Closes #135