### PR TITLE
[F-011] Command palette trigger button missing aria-expanded state (WCAG 4.1.2)

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -144,6 +144,7 @@
         id="palette-trigger-btn"
         title="Command palette (Ctrl+K)"
         aria-label="Open command palette"
+        aria-expanded="false"
         class="nav-icon-btn palette-trigger">
         ⌘
       </button>

--- a/freeforge/src/features/palette.js
+++ b/freeforge/src/features/palette.js
@@ -58,6 +58,7 @@ export function openPalette() {
   const input = document.getElementById('cmd-search');
   if (!palette || !input) return;
   palette.classList.remove('hidden');
+  document.getElementById('palette-trigger-btn')?.setAttribute('aria-expanded', 'true');
   input.value = '';
   render('');
   input.focus();
@@ -65,6 +66,7 @@ export function openPalette() {
 
 export function closePalette() {
   document.getElementById('cmd-palette')?.classList.add('hidden');
+  document.getElementById('palette-trigger-btn')?.setAttribute('aria-expanded', 'false');
   if (previousFocus && document.contains(previousFocus)) previousFocus.focus();
   previousFocus = null;
 }

--- a/tests/security/palette-expanded.test.mjs
+++ b/tests/security/palette-expanded.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+test('palette trigger tracks expanded state across open and close', async () => {
+  const html = await readFile(path.resolve('freeforge/index.html'), 'utf8');
+
+  assert.match(html, /<button[^>]*id="palette-trigger-btn"[^>]*aria-expanded="false"/);
+  assert.match(html, /id="palette-trigger-btn"[^>]*aria-label="Open command palette"[^>]*aria-expanded="false"/);
+  const js = await readFile(path.resolve('freeforge/src/features/palette.js'), 'utf8');
+  assert.match(js, /setAttribute\('aria-expanded', 'true'\)/);
+  assert.match(js, /setAttribute\('aria-expanded', 'false'\)/);
+});


### PR DESCRIPTION
## Summary
Exposed palette expanded state on the trigger button and kept it in sync when the palette opens and closes.

## Root Cause
The trigger button did not report open/closed state programmatically.

## Scoped Changes
- `freeforge/index.html`
- `freeforge/src/features/palette.js`
- `tests/security/palette-expanded.test.mjs`

## Tests and Exact Results
`node --test tests/security/palette-expanded.test.mjs` -> 1 test passed.

## Risk
Low. The fix only adds state signaling for assistive tech.

## Rollback
Remove the `aria-expanded` wiring and the regression test.

## Dependencies
Related to #137, but implemented independently.

## Evidence
The HTML starts with `aria-expanded="false"`, and the JS toggles it on open/close.

Closes #136