### PR TITLE
[F-006] Add aria-label to chat-screen nav landmark (WCAG 2.4.1)

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -106,7 +106,7 @@
   </div>
 
   <!-- Nav -->
-  <nav class="surface-strip flex items-center gap-3 px-4 py-3 border-b border-zinc-800 flex-shrink-0">
+  <nav aria-label="Application navigation" class="surface-strip flex items-center gap-3 px-4 py-3 border-b border-zinc-800 flex-shrink-0">
     <div class="flex items-center gap-2 flex-shrink-0">
       <div class="w-7 h-7 rounded-lg flex items-center justify-center gradient-btn flex-shrink-0">
         <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary

- Adds `aria-label="Application navigation"` to the `<nav>` element at `freeforge/index.html:109`
- Single additive attribute; no visual, JS, or CSS changes

## Root Cause

The `<nav>` element was added without an accessible label. When a page has multiple landmark regions (nav, dialogs, log), WCAG 2.4.1 requires each to carry a distinguishable label so screen reader users can navigate meaningfully. The settings modal and command palette already carry correct `aria-label` attributes; the nav bar did not.

## Scoped Changes

| File | Change |
|---|---|
| `freeforge/index.html` | `<nav>` at line 109: added `aria-label="Application navigation"` |

## Tests and Results

```
node --test tests/security/*.mjs
# tests 43
# pass 43
# fail 0
```

Acceptance criteria verified:
```bash
grep -n 'aria-label' freeforge/index.html | grep nav
# 109:  <nav aria-label="Application navigation" class="surface-strip ...">
```

## Risk

Additive attribute. Zero impact on visual appearance, JavaScript behavior, or CSS specificity. Non-AT browsers ignore `aria-label` on block elements.

## Rollback

Revert the single attribute addition to `freeforge/index.html:109`.

## Dependencies

None.

## Audit Evidence

- Audit run: `20260628T183331Z`
- Finding: F-006
- Base SHA: `f81d0c2a73c3f344ae5638ebfdf122ea60bff84d`

Closes #150