### PR TITLE
[F-009] Sync CLAUDE.md Technology Stack with deployed dependency versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,17 +82,17 @@ The v1 implementation is feature-complete: onboarding with key validation, strea
 
 - None — FreeForge uses vanilla ES modules with no framework
 - Claude Code settings schema (`https://json.schemastore.org/claude-code-settings.json`) governs `.claude/settings.json`
-- Tailwind CSS v3 (JIT) — Loaded via CDN at `https://cdn.tailwindcss.com` in `freeforge/index.html`; no local install
-- marked v9.1.6 — Loaded via jsDelivr CDN with SRI hash in `freeforge/index.html`
-- DOMPurify v3.1.6 — Loaded via jsDelivr CDN with SRI hash in `freeforge/index.html`
+- Tailwind CSS v3 — Bundled locally as `freeforge/styles/tailwind.min.css`; no CDN
+- marked v18.0.4 — Loaded via jsDelivr CDN with SRI hash in `freeforge/index.html`
+- DOMPurify v3.4.8 — Loaded via jsDelivr CDN with SRI hash in `freeforge/index.html`
 - Not detected — No test framework, test files, or test scripts present
 - Not detected — No bundler (Vite, webpack, esbuild, etc.), no build step; files are served as-is
 
 ## Key Dependencies
 
-- `marked@9.1.6` — Markdown-to-HTML rendering for AI responses (`freeforge/src/markdown.js`)
-- `dompurify@3.1.6` — XSS sanitization of rendered LLM output (`freeforge/src/markdown.js`)
-- `tailwindcss@3` (JIT CDN) — All UI styling in `freeforge/index.html`
+- `marked@18.0.4` — Markdown-to-HTML rendering for AI responses (`freeforge/src/markdown.js`)
+- `dompurify@3.4.8` — XSS sanitization of rendered LLM output (`freeforge/src/markdown.js`)
+- `tailwindcss@3` (local bundle) — All UI styling in `freeforge/index.html`
 - Node.js standard library — Used by hook scripts in `.claude/hooks/**/*.js` (fs, path, child_process implied)
 
 ## Configuration


### PR DESCRIPTION
## Summary

- Updates 6 stale version/hosting references in `CLAUDE.md` Technology Stack section to match `freeforge/index.html`
- Documentation-only change; no runtime code, tests, or configuration altered

## Root Cause

`CLAUDE.md` was not updated when:
1. `marked` was upgraded from `9.1.6` → `18.0.4`
2. `DOMPurify` was upgraded from `3.1.6` → `3.4.8`
3. Tailwind was migrated from `cdn.tailwindcss.com` JIT loader to local `styles/tailwind.min.css`

Contributors and AI agents reading the stale section would cite wrong versions in security reviews, changelogs, and dependency audits.

## Scoped Changes

| CLAUDE.md line | Before | After |
|---|---|---|
| 85 | `Tailwind CSS v3 (JIT) — Loaded via CDN at cdn.tailwindcss.com` | `Tailwind CSS v3 — Bundled locally as freeforge/styles/tailwind.min.css; no CDN` |
| 86 | `marked v9.1.6 — Loaded via jsDelivr CDN` | `marked v18.0.4 — Loaded via jsDelivr CDN` |
| 87 | `DOMPurify v3.1.6 — Loaded via jsDelivr CDN` | `DOMPurify v3.4.8 — Loaded via jsDelivr CDN` |
| 93 | `` `marked@9.1.6` `` | `` `marked@18.0.4` `` |
| 94 | `` `dompurify@3.1.6` `` | `` `dompurify@3.4.8` `` |
| 95 | `` `tailwindcss@3` (JIT CDN) `` | `` `tailwindcss@3` (local bundle) `` |

## Tests and Results

```bash
grep -n 'marked' CLAUDE.md freeforge/index.html
# CLAUDE.md:86:- marked v18.0.4 — Loaded via jsDelivr CDN ...
# CLAUDE.md:93:- `marked@18.0.4` — Markdown-to-HTML rendering ...
# freeforge/index.html:10:  <script src="https://cdn.jsdelivr.net/npm/marked@18.0.4/...

grep -n 'tailwind' CLAUDE.md freeforge/index.html
# CLAUDE.md:85:- Tailwind CSS v3 — Bundled locally as `freeforge/styles/tailwind.min.css`; no CDN
# CLAUDE.md:95:- `tailwindcss@3` (local bundle) — All UI styling in `freeforge/index.html`
# freeforge/index.html:9:  <link rel="stylesheet" href="styles/tailwind.min.css">

grep -n 'dompurify\|DOMPurify' CLAUDE.md freeforge/index.html
# CLAUDE.md:87:- DOMPurify v3.4.8 — Loaded via jsDelivr CDN ...
# CLAUDE.md:94:- `dompurify@3.4.8` — XSS sanitization ...
# freeforge/index.html:13:  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.8/...
```

All CLAUDE.md references now match `freeforge/index.html` declarations. No stale `9.1.6`, `3.1.6`, `cdn.tailwindcss.com`, or "JIT CDN" references remain.

## Risk

Documentation-only; zero runtime or security risk.

## Rollback

Revert the `CLAUDE.md` edit.

## Dependencies

None.

## Audit Evidence

- Audit run: `20260628T183331Z`
- Finding: F-009
- Base SHA: `f81d0c2a73c3f344ae5638ebfdf122ea60bff84d`

Closes #151