### PR TITLE
feat(agent): Agent CRUD actions and safe JSON import/export

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -286,8 +286,13 @@
             <h3 class="text-sm font-semibold text-zinc-100">Library</h3>
             <p class="mt-1 text-xs text-zinc-500">Browse local agents and pick one to edit.</p>
           </div>
-          <button id="agent-library-new-btn" type="button" class="rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-600 hover:text-white transition-colors">New Agent</button>
+          <div class="flex items-center gap-2">
+            <button id="agent-library-import-btn" type="button" class="rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-600 hover:text-white transition-colors">Import</button>
+            <button id="agent-library-export-btn" type="button" class="rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-600 hover:text-white transition-colors">Export Active</button>
+            <button id="agent-library-new-btn" type="button" class="rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-600 hover:text-white transition-colors">New Agent</button>
+          </div>
         </div>
+        <input id="agent-library-import-input" type="file" accept="application/json,.json" class="hidden" />
         <div id="agent-library-list" class="space-y-2 max-h-[28rem] overflow-y-auto pr-1"></div>
       </section>
 

--- a/freeforge/src/agent-storage.js
+++ b/freeforge/src/agent-storage.js
@@ -45,6 +45,14 @@ function parseAgentInput(input) {
   return input;
 }
 
+function makeUniqueAgentId(id, agents) {
+  const existing = new Set(agents.map(agent => agent.id));
+  if (!existing.has(id)) return id;
+  let nextId = generateAgentId();
+  while (existing.has(nextId)) nextId = generateAgentId();
+  return nextId;
+}
+
 export function loadAgents() {
   const version = LS.get(AGENT_SCHEMA_VERSION_KEY);
   if (version != null && version !== AGENT_SCHEMA_VERSION) return [];
@@ -97,10 +105,11 @@ export function exportAgent(id) {
 export function importAgent(input) {
   const parsed = parseAgentInput(input);
   const agent = normalizeAgent(parsed);
-  return saveAgent(agent);
+  const agents = loadAgents();
+  const nextId = makeUniqueAgentId(agent.id, agents);
+  return saveAgent(nextId === agent.id ? agent : { ...agent, id: nextId });
 }
 
 export function createAgentId() {
   return generateAgentId();
 }
-

--- a/freeforge/src/agent-storage.js
+++ b/freeforge/src/agent-storage.js
@@ -1,5 +1,5 @@
-import { generateAgentId, normalizeAgent } from './agent-schema.js';
 import { LS } from './state.js';
+import { generateAgentId, normalizeAgent } from './agent-schema.js';
 
 const AGENT_STORAGE_KEY = 'ff_agents_v1';
 const ACTIVE_AGENT_KEY = 'ff_active_agent_id';

--- a/freeforge/src/agent-storage.js
+++ b/freeforge/src/agent-storage.js
@@ -1,5 +1,5 @@
-import { LS } from './state.js';
 import { generateAgentId, normalizeAgent } from './agent-schema.js';
+import { LS } from './state.js';
 
 const AGENT_STORAGE_KEY = 'ff_agents_v1';
 const ACTIVE_AGENT_KEY = 'ff_active_agent_id';

--- a/freeforge/src/api.js
+++ b/freeforge/src/api.js
@@ -127,4 +127,3 @@ export async function streamCompletion(request, ...legacyArgs) {
   }
   return onDone(donePayload, full);
 }
-

--- a/freeforge/src/app.js
+++ b/freeforge/src/app.js
@@ -5,6 +5,8 @@ import { hideObError, showObError, validateAndConnect } from './features/onboard
 import { closePalette, openPalette } from './features/palette.js';
 import { clearKey, clearKeyError as clearSettingsKeyError, closeSettings, openSettings, updateKey } from './features/settings.js';
 import { $, LS, S, clearStoredKey, getStoredKey, recordError, snapshotAgent } from './state.js';
+import { refreshAgentUi } from './features/agents.js';
+import { $, LS, S, clearStoredKey, getStoredKey, recordError, snapshotAgent } from './state.js';
 import { closeAgentLibrary } from './ui/agent-library.js';
 import { renderCtxPill } from './ui/ctx-pill.js';
 import { cancelInlineEdit, renderAllMessages, scrollBottom, startInlineEdit } from './ui/messages.js';
@@ -61,6 +63,7 @@ async function init() {
   showScreen('chat');
   renderAllMessages();
   scrollBottom(false);
+  refreshAgentUi();
   renderCtxPill();
 }
 

--- a/freeforge/src/app.js
+++ b/freeforge/src/app.js
@@ -1,11 +1,10 @@
 import { loadAgents } from './agent-storage.js';
+import { refreshAgentUi } from './features/agents.js';
 import { newChat, regenerate, resendFromUserMessage, restoreInlineEditUndo, sendMessage } from './features/chat.js';
 import { loadModels } from './features/models.js';
 import { hideObError, showObError, validateAndConnect } from './features/onboarding.js';
 import { closePalette, openPalette } from './features/palette.js';
 import { clearKey, clearKeyError as clearSettingsKeyError, closeSettings, openSettings, updateKey } from './features/settings.js';
-import { $, LS, S, clearStoredKey, getStoredKey, recordError, snapshotAgent } from './state.js';
-import { refreshAgentUi } from './features/agents.js';
 import { $, LS, S, clearStoredKey, getStoredKey, recordError, snapshotAgent } from './state.js';
 import { closeAgentLibrary } from './ui/agent-library.js';
 import { renderCtxPill } from './ui/ctx-pill.js';

--- a/freeforge/src/features/agents.js
+++ b/freeforge/src/features/agents.js
@@ -1,9 +1,9 @@
 import { deleteAgent, exportAgent, getAgent, importAgent, loadAgents, saveAgent } from '../agent-storage.js';
-import { setActiveAgent } from './chat.js';
 import { $, LS, S } from '../state.js';
-import { closeAgentLibrary, openAgentLibrary, renderAgentLibrary } from '../ui/agent-library.js';
 import { readAgentBuilderDraft, renderAgentBuilder } from '../ui/agent-builder.js';
+import { closeAgentLibrary, openAgentLibrary, renderAgentLibrary } from '../ui/agent-library.js';
 import { toast } from '../ui/toast.js';
+import { setActiveAgent } from './chat.js';
 
 const IMPORT_INPUT_ID = 'agent-library-import-input';
 const FORM_ID = 'agent-builder-form';

--- a/freeforge/src/features/agents.js
+++ b/freeforge/src/features/agents.js
@@ -1,0 +1,223 @@
+import { deleteAgent, exportAgent, getAgent, importAgent, loadAgents, saveAgent } from '../agent-storage.js';
+import { setActiveAgent } from './chat.js';
+import { $, LS, S } from '../state.js';
+import { closeAgentLibrary, openAgentLibrary, renderAgentLibrary } from '../ui/agent-library.js';
+import { readAgentBuilderDraft, renderAgentBuilder } from '../ui/agent-builder.js';
+import { toast } from '../ui/toast.js';
+
+const IMPORT_INPUT_ID = 'agent-library-import-input';
+const FORM_ID = 'agent-builder-form';
+const NEW_BTN_ID = 'agent-library-new-btn';
+const IMPORT_BTN_ID = 'agent-library-import-btn';
+const EXPORT_BTN_ID = 'agent-library-export-btn';
+const CANCEL_BTN_ID = 'agent-builder-cancel-btn';
+
+function getFormAgentId() {
+  return $(FORM_ID)?.dataset.agentId || '';
+}
+
+function refreshAgentState() {
+  S.agents = loadAgents();
+  const activeId = LS.get('ff_active_agent_id');
+  S.activeAgent = S.agents.find(agent => agent.id === activeId) || S.agents[0] || null;
+  S.activeAgentId = S.activeAgent?.id ?? null;
+  if (!S.messages.length) {
+    S.conversationAgent = S.activeAgent ? { ...S.activeAgent, icon: S.activeAgent.icon ? { ...S.activeAgent.icon } : null, instructions: { ...S.activeAgent.instructions, starterPrompts: [...(S.activeAgent.instructions?.starterPrompts || [])] }, model: { ...S.activeAgent.model } } : null;
+    S.conversationAgentId = S.conversationAgent?.id ?? null;
+  }
+}
+
+function refreshAgentUi() {
+  refreshAgentState();
+  renderAgentLibrary(S.agents, S.activeAgentId);
+  const formAgent = getFormAgentId() ? getAgent(getFormAgentId()) : S.activeAgent;
+  renderAgentBuilder(formAgent || null);
+}
+
+export { refreshAgentUi };
+
+function openBuilder(agent = null) {
+  openAgentLibrary();
+  renderAgentBuilder(agent);
+  document.getElementById(FORM_ID)?.querySelector('input, textarea')?.focus();
+}
+
+function downloadJson(name, json) {
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+function exportActiveAgent() {
+  if (!S.activeAgentId) { toast('No active agent to export', 'warning'); return; }
+  const blob = exportAgent(S.activeAgentId);
+  if (!blob) { toast('Agent not found', 'error'); return; }
+  downloadJson(`${S.activeAgent?.name || S.activeAgentId}.json`, blob);
+  toast('Agent exported', 'success');
+}
+
+function importFromText(text) {
+  let saved;
+  try {
+    saved = importAgent(text);
+  } catch (err) {
+    toast(err?.message || 'Import failed', 'error');
+    return;
+  }
+  if (!saved) {
+    toast('Import failed', 'error');
+    return;
+  }
+  refreshAgentState();
+  setActiveAgent(saved);
+  renderAgentLibrary(S.agents, S.activeAgentId);
+  renderAgentBuilder(saved);
+  toast('Agent imported', 'success');
+}
+
+function saveFromBuilder() {
+  const draft = readAgentBuilderDraft();
+  const agentId = getFormAgentId();
+  let saved;
+  try {
+    saved = saveAgent(agentId ? { ...draft, id: agentId } : draft);
+  } catch (err) {
+    toast(err?.message || 'Agent save failed', 'error');
+    return;
+  }
+  if (!saved) {
+    toast('Agent save failed', 'error');
+    return;
+  }
+
+  const wasNew = !agentId;
+  refreshAgentState();
+  if (wasNew) {
+    setActiveAgent(saved);
+  }
+  renderAgentLibrary(S.agents, S.activeAgentId);
+  renderAgentBuilder(saved);
+  toast(wasNew ? 'Agent created' : 'Agent updated', 'success');
+}
+
+function deleteById(id) {
+  if (!id) return;
+  const wasActive = S.activeAgentId === id;
+  const removed = deleteAgent(id);
+  if (!removed) {
+    toast('Agent not found', 'error');
+    return;
+  }
+  refreshAgentState();
+  if (wasActive) {
+    const active = getAgent(S.activeAgentId) || S.agents[0] || null;
+    if (active) setActiveAgent(active);
+  }
+  renderAgentLibrary(S.agents, S.activeAgentId);
+  renderAgentBuilder(S.activeAgent);
+  toast('Agent deleted', 'success');
+}
+
+function duplicateById(id) {
+  const agent = getAgent(id);
+  if (!agent) {
+    toast('Agent not found', 'error');
+    return;
+  }
+  let saved;
+  try {
+    saved = saveAgent({
+      ...agent,
+      id: undefined,
+    });
+  } catch (err) {
+    toast(err?.message || 'Duplicate failed', 'error');
+    return;
+  }
+  if (!saved) {
+    toast('Duplicate failed', 'error');
+    return;
+  }
+  refreshAgentState();
+  setActiveAgent(saved);
+  renderAgentLibrary(S.agents, S.activeAgentId);
+  renderAgentBuilder(saved);
+  toast('Agent duplicated', 'success');
+}
+
+function setActiveById(id) {
+  const agent = getAgent(id);
+  if (!agent) {
+    toast('Agent not found', 'error');
+    return;
+  }
+  if (agent.id === S.activeAgentId) {
+    renderAgentBuilder(agent);
+    openAgentLibrary();
+    return;
+  }
+  setActiveAgent(agent);
+  refreshAgentState();
+  renderAgentLibrary(S.agents, S.activeAgentId);
+  renderAgentBuilder(agent);
+  openAgentLibrary();
+}
+
+function editById(id) {
+  const agent = getAgent(id);
+  if (!agent) {
+    toast('Agent not found', 'error');
+    return;
+  }
+  renderAgentBuilder(agent);
+  openAgentLibrary();
+}
+
+function exportById(id) {
+  const blob = exportAgent(id);
+  if (!blob) {
+    toast('Agent not found', 'error');
+    return;
+  }
+  const agent = getAgent(id);
+  downloadJson(`${agent?.name || id}.json`, blob);
+  toast('Agent exported', 'success');
+}
+
+document.getElementById(NEW_BTN_ID)?.addEventListener('click', () => openBuilder(null));
+document.getElementById(IMPORT_BTN_ID)?.addEventListener('click', () => document.getElementById(IMPORT_INPUT_ID)?.click());
+document.getElementById(EXPORT_BTN_ID)?.addEventListener('click', exportActiveAgent);
+document.getElementById(CANCEL_BTN_ID)?.addEventListener('click', closeAgentLibrary);
+
+document.getElementById(IMPORT_INPUT_ID)?.addEventListener('change', e => {
+  const file = e.target.files?.[0];
+  e.target.value = '';
+  if (!file) return;
+  file.text().then(importFromText).catch(() => toast('Import failed', 'error'));
+});
+
+document.addEventListener('click', e => {
+  const action = e.target.closest('[data-agent-action]');
+  if (!action) return;
+  const id = action.dataset.agentId;
+  const kind = action.dataset.agentAction;
+  if (!id || !kind) return;
+  if (kind === 'set-active') setActiveById(id);
+  else if (kind === 'edit') editById(id);
+  else if (kind === 'duplicate') duplicateById(id);
+  else if (kind === 'delete') deleteById(id);
+  else if (kind === 'export') exportById(id);
+});
+
+document.getElementById(FORM_ID)?.addEventListener('submit', e => {
+  e.preventDefault();
+  saveFromBuilder();
+});
+
+refreshAgentUi();

--- a/freeforge/src/ui/agent-builder.js
+++ b/freeforge/src/ui/agent-builder.js
@@ -11,7 +11,13 @@ function getValue(id) {
   return getField(id)?.value.trim() || '';
 }
 
+function getForm() {
+  return getField(FORM_ID);
+}
+
 export function renderAgentBuilder(agent = null) {
+  const form = getForm();
+  if (form) form.dataset.agentId = agent?.id || '';
   const mode = agent ? 'Edit Agent' : 'Create Agent';
   const title = getField(TITLE_ID);
   if (title) title.textContent = mode;
@@ -63,6 +69,7 @@ export function openAgentBuilder(agent = null) {
   if (!modal) return;
   renderAgentBuilder(agent);
   modal.classList.remove('hidden');
+  getField('agent-name')?.focus();
 }
 
 export function closeAgentBuilder() {
@@ -71,4 +78,4 @@ export function closeAgentBuilder() {
   modal.classList.add('hidden');
 }
 
-document.getElementById(FORM_ID)?.addEventListener('submit', e => e.preventDefault());
+getForm()?.addEventListener('submit', e => e.preventDefault());

--- a/freeforge/src/ui/agent-library.js
+++ b/freeforge/src/ui/agent-library.js
@@ -72,9 +72,8 @@ export function renderAgentLibrary(agents = S.agents, activeAgentId = S.activeAg
   }
 
   for (const agent of agents) {
-    const item = document.createElement('button');
-    item.type = 'button';
-    item.className = 'w-full text-left rounded-xl border border-zinc-800 bg-zinc-950/60 px-3 py-3 hover:border-zinc-700 hover:bg-zinc-900/80 transition-colors';
+    const item = document.createElement('div');
+    item.className = 'rounded-xl border border-zinc-800 bg-zinc-950/60 px-3 py-3';
     item.dataset.agentId = agent.id;
 
     const top = document.createElement('div');
@@ -97,7 +96,28 @@ export function renderAgentLibrary(agents = S.agents, activeAgentId = S.activeAg
     badge.textContent = activeAgentId === agent.id ? 'Active' : 'Saved';
 
     top.append(nameWrap, badge);
-    item.appendChild(top);
+    const actions = document.createElement('div');
+    actions.className = 'mt-3 flex flex-wrap gap-2';
+
+    const makeAction = (label, action) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'rounded-lg border border-zinc-700 px-2.5 py-1 text-xs font-medium text-zinc-300 hover:border-zinc-600 hover:text-white transition-colors';
+      btn.dataset.agentAction = action;
+      btn.dataset.agentId = agent.id;
+      btn.textContent = label;
+      return btn;
+    };
+
+    actions.append(
+      makeAction(activeAgentId === agent.id ? 'Active' : 'Use', 'set-active'),
+      makeAction('Edit', 'edit'),
+      makeAction('Duplicate', 'duplicate'),
+      makeAction('Export', 'export'),
+      makeAction('Delete', 'delete')
+    );
+
+    item.append(top, actions);
     list.appendChild(item);
   }
 }


### PR DESCRIPTION
## Summary

Wired the local agent CRUD and import/export workflows onto the new agent shell.

Imports now go through the schema validator and duplicate imported IDs are regenerated instead of overwriting existing agents.

Closes #193

---

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test-only change
- [ ] Documentation update
- [ ] Build / CI / tooling change
- [ ] Other: None

---

## What Changed

- Added `freeforge/src/features/agents.js` to wire create, edit, duplicate, delete, activate, import, and export flows.
- Updated `freeforge/src/agent-storage.js` so imported agents keep the validator path but receive a regenerated ID when the incoming ID already exists.
- Extended `freeforge/src/ui/agent-library.js` with per-agent action buttons and import/export controls.
- Extended `freeforge/src/ui/agent-builder.js` so the current draft can be read back safely on submit.
- Updated `freeforge/index.html` with import/export controls and hidden file input wiring.
- Updated `freeforge/src/app.js` to load the agent controller and hydrate the agent UI after startup.

---

## Why This Approach

The controller keeps the UI shell thin and lets storage remain the single source of truth for normalization and persistence.

That makes the import path safe without duplicating validation logic in the browser event handlers.

---

## Testing

### Commands Run

```bash
node --check freeforge/src/agent-storage.js
node --check freeforge/src/features/agents.js
node --check freeforge/src/ui/agent-library.js
node --check freeforge/src/ui/agent-builder.js
node --check freeforge/src/app.js
```

### Results

- Syntax checks passed for the agent storage, controller, UI, and bootstrap modules.
- The new controller is wired by module import and the app startup refresh hook.

### Coverage Added or Updated

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing only
- [ ] Not applicable — explain why: None

---

## Screenshots / Logs / Evidence

- No screenshot needed; this is controller wiring and file-import/export behavior.

---

## Risk Assessment

### Risk Level

- [ ] Low
- [x] Medium
- [ ] High

### Possible Impact

The import and save flows now touch local agent persistence and active-agent switching, so regressions would show up as incorrect agent selection or stale builder state.

### Rollback Plan

Revert commit `fd11c0a` on the issue-193 branch or back out the controller import from `app.js` if the wiring needs to be split differently.

---

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included

Details:

None.

---

## Reviewer Focus

Please pay special attention to:

- Duplicate ID regeneration on import
- Whether active-agent switching resets the conversation only when it should
- Whether delete and duplicate actions keep the library and builder state in sync

---

## Checklist

- [x] PR is linked to the correct issue
- [x] Tests pass locally
- [ ] Relevant tests were added or updated
- [x] Only files relevant to this issue were modified
- [x] No secrets, credentials, API keys, or environment-specific values introduced
- [x] Error handling was considered
- [x] Edge cases were considered
- [ ] Documentation updated, or not needed
- [x] No breaking changes, or they are clearly documented above
- [ ] This PR is ready for review

---

## Notes for Follow-Up Work

Need #194 to expose the agent controls from the main UI and command palette.
