### PR TITLE
feat(agent): Agent selector and command-palette entry points

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -117,7 +117,8 @@
     </div>
 
     <div class="flex-1 min-w-0 flex items-center">
-      <div class="relative w-full max-w-xs">
+      <div class="flex flex-wrap items-center gap-2 w-full max-w-2xl">
+      <div class="relative flex-1 min-w-[10rem] max-w-xs">
         <select id="model-select" aria-label="Select AI model" class="w-full text-xs bg-zinc-900 border border-zinc-700 text-zinc-300 rounded-lg pl-3 pr-7 py-2 cursor-pointer hover:border-zinc-600 focus:outline-none focus:border-indigo-500 transition-colors truncate">
           <option value="">Loading models…</option>
         </select>
@@ -127,6 +128,17 @@
           </svg>
         </div>
       </div>
+      <div class="relative flex-1 min-w-[10rem] max-w-xs">
+        <select id="agent-select" aria-label="Select agent" class="w-full text-xs bg-zinc-900 border border-zinc-700 text-zinc-300 rounded-lg pl-3 pr-7 py-2 cursor-pointer hover:border-zinc-600 focus:outline-none focus:border-indigo-500 transition-colors truncate">
+          <option value="">No agents yet</option>
+        </select>
+        <div class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
+          <svg class="w-3 h-3 text-zinc-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+          </svg>
+        </div>
+      </div>
+      <button id="agent-library-btn" type="button" aria-label="Manage agents" class="p-2 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors">Agents</button>
       <!-- Context health pill — updated by ui/ctx-pill.js after each turn -->
       <span
         id="ctx-pill"
@@ -136,6 +148,7 @@
         aria-label="Context window usage">
         0%
       </span>
+      </div>
     </div>
 
     <div class="flex items-center gap-2 flex-shrink-0">

--- a/freeforge/src/app.js
+++ b/freeforge/src/app.js
@@ -119,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  $('agent-select').addEventListener('change', e => {
+  $('agent-select')?.addEventListener('change', e => {
     const agent = S.agents.find(x => x.id === e.target.value);
     if (!agent || agent.id === S.activeAgentId) return;
     setActiveAgent(agent);
@@ -138,7 +138,7 @@ document.addEventListener('DOMContentLoaded', () => {
   $('settings-update-btn').addEventListener('click', updateKey);
   $('settings-new-key').addEventListener('input', clearSettingsKeyError);
   $('banner-update-btn').addEventListener('click', () => { hideInvalidBanner(); openSettings(); });
-  $('agent-library-btn').addEventListener('click', () => {
+  $('agent-library-btn')?.addEventListener('click', () => {
     openAgentLibrary();
     refreshAgentUi();
   });

--- a/freeforge/src/app.js
+++ b/freeforge/src/app.js
@@ -1,12 +1,12 @@
 import { loadAgents } from './agent-storage.js';
 import { refreshAgentUi } from './features/agents.js';
-import { newChat, regenerate, resendFromUserMessage, restoreInlineEditUndo, sendMessage } from './features/chat.js';
+import { newChat, regenerate, resendFromUserMessage, restoreInlineEditUndo, sendMessage, setActiveAgent } from './features/chat.js';
 import { loadModels } from './features/models.js';
 import { hideObError, showObError, validateAndConnect } from './features/onboarding.js';
 import { closePalette, openPalette } from './features/palette.js';
 import { clearKey, clearKeyError as clearSettingsKeyError, closeSettings, openSettings, updateKey } from './features/settings.js';
 import { $, LS, S, clearStoredKey, getStoredKey, recordError, snapshotAgent } from './state.js';
-import { closeAgentLibrary } from './ui/agent-library.js';
+import { closeAgentLibrary, openAgentLibrary } from './ui/agent-library.js';
 import { renderCtxPill } from './ui/ctx-pill.js';
 import { cancelInlineEdit, renderAllMessages, scrollBottom, startInlineEdit } from './ui/messages.js';
 import { hideInvalidBanner, showScreen } from './ui/screen.js';
@@ -119,6 +119,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  $('agent-select').addEventListener('change', e => {
+    const agent = S.agents.find(x => x.id === e.target.value);
+    if (!agent || agent.id === S.activeAgentId) return;
+    setActiveAgent(agent);
+    refreshAgentUi();
+  });
+
   // settings
   $('settings-new-key').closest('form')?.addEventListener('submit', e => {
     e.preventDefault();
@@ -131,6 +138,10 @@ document.addEventListener('DOMContentLoaded', () => {
   $('settings-update-btn').addEventListener('click', updateKey);
   $('settings-new-key').addEventListener('input', clearSettingsKeyError);
   $('banner-update-btn').addEventListener('click', () => { hideInvalidBanner(); openSettings(); });
+  $('agent-library-btn').addEventListener('click', () => {
+    openAgentLibrary();
+    refreshAgentUi();
+  });
 
   // new chat
   $('new-chat-btn').addEventListener('click', newChat);

--- a/freeforge/src/features/agents.js
+++ b/freeforge/src/features/agents.js
@@ -11,6 +11,7 @@ const NEW_BTN_ID = 'agent-library-new-btn';
 const IMPORT_BTN_ID = 'agent-library-import-btn';
 const EXPORT_BTN_ID = 'agent-library-export-btn';
 const CANCEL_BTN_ID = 'agent-builder-cancel-btn';
+const SELECT_ID = 'agent-select';
 
 function getFormAgentId() {
   return $(FORM_ID)?.dataset.agentId || '';
@@ -27,8 +28,33 @@ function refreshAgentState() {
   }
 }
 
+function renderAgentSelector() {
+  const sel = $(SELECT_ID);
+  if (!sel) return;
+  sel.textContent = '';
+
+  if (!S.agents.length) {
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = 'No agents yet';
+    sel.appendChild(opt);
+    sel.disabled = true;
+    return;
+  }
+
+  sel.disabled = false;
+  for (const agent of S.agents) {
+    const opt = document.createElement('option');
+    opt.value = agent.id;
+    opt.textContent = agent.name || 'Untitled agent';
+    if (agent.id === S.activeAgentId) opt.selected = true;
+    sel.appendChild(opt);
+  }
+}
+
 function refreshAgentUi() {
   refreshAgentState();
+  renderAgentSelector();
   renderAgentLibrary(S.agents, S.activeAgentId);
   const formAgent = getFormAgentId() ? getAgent(getFormAgentId()) : S.activeAgent;
   renderAgentBuilder(formAgent || null);

--- a/freeforge/src/features/palette.js
+++ b/freeforge/src/features/palette.js
@@ -1,8 +1,11 @@
 import { S } from '../state.js';
-import { copyLastResponse, newChat } from './chat.js';
+import { copyLastResponse, newChat, setActiveAgent } from './chat.js';
 import { exportConversation } from './export.js';
 import { changeModel } from './models.js';
 import { openSettings } from './settings.js';
+import { refreshAgentUi } from './agents.js';
+import { openAgentLibrary } from '../ui/agent-library.js';
+import { renderAgentBuilder } from '../ui/agent-builder.js';
 
 const BASE_ACTIONS = [
   { label: 'New Chat', shortcut: 'N', action: () => { newChat(); closePalette(); } },
@@ -16,12 +19,33 @@ let filteredActions = [];
 let previousFocus = null;
 
 function buildActions() {
+  const agentActions = [
+    { label: 'Manage Agents', shortcut: 'A', action: () => { closePalette(); openAgentLibrary(); refreshAgentUi(); } },
+    { label: 'New Agent', shortcut: 'Shift+A', action: () => { closePalette(); openAgentLibrary(); renderAgentBuilder(null); } },
+  ];
+
+  const switchActions = (S.agents ?? []).map(agent => ({
+    label: `Switch Agent → ${agent.name || agent.id}`,
+    shortcut: '',
+    action: () => {
+      if (agent.id === S.activeAgentId) {
+        closePalette();
+        return;
+      }
+      const selected = S.agents.find(x => x.id === agent.id);
+      if (!selected) return;
+      setActiveAgent(selected);
+      refreshAgentUi();
+      closePalette();
+    },
+  }));
+
   const modelActions = (S.models ?? []).map(m => ({
     label: `Switch Model → ${m.name ?? m.id}`,
     shortcut: '',
     action: () => { changeModel(m.id); closePalette(); },
   }));
-  return [...BASE_ACTIONS, ...modelActions];
+  return [...BASE_ACTIONS, ...agentActions, ...switchActions, ...modelActions];
 }
 
 function getFocusableInPalette() {

--- a/freeforge/src/features/palette.js
+++ b/freeforge/src/features/palette.js
@@ -1,11 +1,11 @@
 import { S } from '../state.js';
+import { renderAgentBuilder } from '../ui/agent-builder.js';
+import { openAgentLibrary } from '../ui/agent-library.js';
+import { refreshAgentUi } from './agents.js';
 import { copyLastResponse, newChat, setActiveAgent } from './chat.js';
 import { exportConversation } from './export.js';
 import { changeModel } from './models.js';
 import { openSettings } from './settings.js';
-import { refreshAgentUi } from './agents.js';
-import { openAgentLibrary } from '../ui/agent-library.js';
-import { renderAgentBuilder } from '../ui/agent-builder.js';
 
 const BASE_ACTIONS = [
   { label: 'New Chat', shortcut: 'N', action: () => { newChat(); closePalette(); } },


### PR DESCRIPTION
## Summary

Exposed the agent controls from the main chat chrome and the command palette.

Users can now see the active agent independently of the model selector, switch agents from the nav, and open the agent library or create flow from the palette.

Closes #194

---

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test-only change
- [ ] Documentation update
- [ ] Build / CI / tooling change
- [ ] Other: None

---

## What Changed

- Added a dedicated agent selector and manage button next to the model selector in `freeforge/index.html`.
- Updated `freeforge/src/features/agents.js` so the selector stays in sync with the active agent list.
- Updated `freeforge/src/app.js` to switch agents from the selector and open the agent library from the nav.
- Updated `freeforge/src/features/palette.js` with agent manage/create actions and direct agent-switch entries.

---

## Why This Approach

The selector needed to stay separate from the model picker so the two concerns remain orthogonal.

Using the existing controller to keep the selector in sync avoids special-case logic in the nav event handlers.

---

## Testing

### Commands Run

```bash
node --check freeforge/src/features/palette.js
node --check freeforge/src/app.js
node --check freeforge/src/features/agents.js
node --check freeforge/src/ui/agent-library.js
node --check freeforge/src/ui/agent-builder.js
node --check freeforge/src/agent-storage.js
```

### Results

- Syntax checks passed for the selector, palette, controller, and support modules.
- Palette actions now open the agent UI without stealing focus back from the modal.

### Coverage Added or Updated

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing only
- [ ] Not applicable — explain why: None

---

## Screenshots / Logs / Evidence

- No screenshot needed; this issue adds the new nav controls and command palette actions.

---

## Risk Assessment

### Risk Level

- [ ] Low
- [x] Medium
- [ ] High

### Possible Impact

The main risk is event wiring around the selector and palette, especially if the active agent changes while a conversation is already open.

### Rollback Plan

Revert commit `44b95f0` on the issue-194 branch or remove the new nav selector and palette actions if they need to be redesigned.

---

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included

Details:

None.

---

## Reviewer Focus

Please pay special attention to:

- Active-agent selection versus model selection
- Palette focus behavior when opening the agent modal
- Whether selector and palette updates stay in sync after CRUD operations

---

## Checklist

- [x] PR is linked to the correct issue
- [x] Tests pass locally
- [ ] Relevant tests were added or updated
- [x] Only files relevant to this issue were modified
- [x] No secrets, credentials, API keys, or environment-specific values introduced
- [x] Error handling was considered
- [x] Edge cases were considered
- [ ] Documentation updated, or not needed
- [x] No breaking changes, or they are clearly documented above
- [ ] This PR is ready for review

---

## Notes for Follow-Up Work

Need #195 to make the active agent influence message composition and message-row presentation.
