### PR TITLE
feat(agent): Agent defaults polish: starters, model prefs, and avatar badge

### DIFF
--- a/freeforge/index.html
+++ b/freeforge/index.html
@@ -187,7 +187,7 @@
       </div>
       <h2 class="text-xl font-semibold text-zinc-200 mb-2">Start a conversation</h2>
       <p class="text-sm text-zinc-500 max-w-sm">Ask anything. Free open-source models via OpenRouter — no cost, no limits.</p>
-      <div class="mt-6 flex flex-wrap gap-2 justify-center">
+      <div id="starter-prompts" class="mt-6 flex flex-wrap gap-2 justify-center">
         <button class="suggestion text-xs px-3 py-1.5 rounded-full border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 transition-colors">Explain quantum computing</button>
         <button class="suggestion text-xs px-3 py-1.5 rounded-full border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 transition-colors">Write a Python script</button>
         <button class="suggestion text-xs px-3 py-1.5 rounded-full border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 transition-colors">Help me brainstorm ideas</button>

--- a/freeforge/src/agent-runtime.js
+++ b/freeforge/src/agent-runtime.js
@@ -13,3 +13,18 @@ export function buildRequestMessages(messages, agent) {
   return payload;
 }
 
+export function buildRequestParameters(agent) {
+  const parameters = {};
+  const temperature = agent?.model?.temperature;
+  if (Number.isFinite(temperature)) parameters.temperature = temperature;
+  const maxTokens = agent?.model?.maxTokens;
+  if (Number.isFinite(maxTokens)) parameters.max_tokens = maxTokens;
+  return parameters;
+}
+
+export function buildRequestContext(messages, agent) {
+  return {
+    messages: buildRequestMessages(messages, agent),
+    parameters: buildRequestParameters(agent),
+  };
+}

--- a/freeforge/src/features/chat.js
+++ b/freeforge/src/features/chat.js
@@ -1,5 +1,5 @@
-import { streamCompletion } from '../api.js';
 import { buildRequestContext } from '../agent-runtime.js';
+import { streamCompletion } from '../api.js';
 import { $, LS, S, snapshotAgent, uid } from '../state.js';
 import { renderCtxPill } from '../ui/ctx-pill.js';
 import { appendNewMessages, renderAllMessages, replaceMessage, scrollBottom, setStreamMode } from '../ui/messages.js';

--- a/freeforge/src/features/chat.js
+++ b/freeforge/src/features/chat.js
@@ -1,5 +1,5 @@
-import { buildRequestMessages } from '../agent-runtime.js';
 import { streamCompletion } from '../api.js';
+import { buildRequestContext } from '../agent-runtime.js';
 import { $, LS, S, snapshotAgent, uid } from '../state.js';
 import { renderCtxPill } from '../ui/ctx-pill.js';
 import { appendNewMessages, renderAllMessages, replaceMessage, scrollBottom, setStreamMode } from '../ui/messages.js';
@@ -111,7 +111,7 @@ export async function sendMessage(text) {
 
   const convoAgent = S.conversationAgent || snapshotAgent(S.activeAgent);
   if (!S.conversationAgent && convoAgent) syncConversationAgent();
-  const payload = buildRequestMessages(S.messages.filter(m => m.id !== asstId), convoAgent);
+  const request = buildRequestContext(S.messages.filter(m => m.id !== asstId), convoAgent);
 
   let firstToken = true;
   const ctrl = new AbortController();
@@ -119,9 +119,10 @@ export async function sendMessage(text) {
   S.streamTarget = null;
 
   await streamCompletion({
-    messages: payload,
+    messages: request.messages,
     modelId: S.selectedModel,
     apiKey: S.apiKey,
+    parameters: request.parameters,
     signal: ctrl.signal,
     onToken(_delta, full) {
       if (firstToken) {

--- a/freeforge/src/features/models.js
+++ b/freeforge/src/features/models.js
@@ -25,6 +25,16 @@ function buildOptions(models) {
   return sel;
 }
 
+function getPreferredAgentModelId() {
+  return S.conversationAgent?.model?.preferredModelId || S.activeAgent?.model?.preferredModelId || null;
+}
+
+function selectModel(sel, modelId) {
+  sel.value = modelId;
+  S.selectedModel = modelId;
+  LS.set('ff_model', modelId);
+}
+
 export async function loadModels(key) {
   const sel = $('model-select');
   sel.innerHTML = '<option value="">Loading models…</option>';
@@ -39,11 +49,20 @@ export async function loadModels(key) {
     const saved = LS.get('ff_model');
     const validSaved = saved && models.find(m => m.id === saved);
     if (validSaved) {
-      sel.value = saved;
-      S.selectedModel = saved;
-    } else {
-      const pick = models[0]?.id;
-      if (pick) { sel.value = pick; S.selectedModel = pick; LS.set('ff_model', pick); }
+      selectModel(sel, saved);
+      return;
+    }
+
+    const preferred = getPreferredAgentModelId();
+    const validPreferred = preferred && models.find(m => m.id === preferred);
+    if (validPreferred) {
+      selectModel(sel, preferred);
+      return;
+    }
+
+    const pick = models[0]?.id;
+    if (pick) {
+      selectModel(sel, pick);
     }
     return 'ok';
   } catch (e) {
@@ -61,8 +80,13 @@ export function populateModelsFromState() {
   buildOptions(S.models);
   const saved = LS.get('ff_model');
   const validSaved = saved && S.models.find(m => m.id === saved);
-  if (validSaved) { sel.value = saved; S.selectedModel = saved; }
-  else if (S.models[0]) { sel.value = S.models[0].id; S.selectedModel = S.models[0].id; }
+  if (validSaved) { selectModel(sel, saved); return; }
+
+  const preferred = getPreferredAgentModelId();
+  const validPreferred = preferred && S.models.find(m => m.id === preferred);
+  if (validPreferred) { selectModel(sel, preferred); return; }
+
+  if (S.models[0]) { selectModel(sel, S.models[0].id); }
 }
 
 export function changeModel(modelId) {

--- a/freeforge/src/ui/agent-builder.js
+++ b/freeforge/src/ui/agent-builder.js
@@ -41,8 +41,15 @@ export function renderAgentBuilder(agent = null) {
   if (openingMessage) openingMessage.value = agent?.instructions?.openingMessage || '';
   if (starterPrompts) starterPrompts.value = (agent?.instructions?.starterPrompts || []).join('\n');
   if (preferredModelId) preferredModelId.value = agent?.model?.preferredModelId || '';
-  if (temperature) temperature.value = agent?.model?.temperature ?? '';
-  if (maxTokens) maxTokens.value = agent?.model?.maxTokens ?? '';
+  if (preferredModelId) preferredModelId.placeholder = 'Optional';
+  if (temperature) {
+    temperature.value = agent?.model?.temperature ?? '';
+    temperature.placeholder = 'Optional';
+  }
+  if (maxTokens) {
+    maxTokens.value = agent?.model?.maxTokens ?? '';
+    maxTokens.placeholder = 'Optional';
+  }
 }
 
 export function readAgentBuilderDraft() {

--- a/freeforge/src/ui/messages.js
+++ b/freeforge/src/ui/messages.js
@@ -3,6 +3,30 @@ import { $, S } from '../state.js';
 import { toast } from './toast.js';
 
 let renderedCount = 0;
+const DEFAULT_STARTER_PROMPTS = [
+  'Explain quantum computing',
+  'Write a Python script',
+  'Help me brainstorm ideas',
+  'Debug my code',
+];
+
+function getStarterPrompts() {
+  const prompts = S.conversationAgent?.instructions?.starterPrompts;
+  return Array.isArray(prompts) && prompts.length ? prompts : DEFAULT_STARTER_PROMPTS;
+}
+
+function renderStarterPrompts() {
+  const host = document.getElementById('starter-prompts');
+  if (!host) return;
+  host.textContent = '';
+  for (const prompt of getStarterPrompts()) {
+    const btn = document.createElement('button');
+    btn.className = 'suggestion text-xs px-3 py-1.5 rounded-full border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 transition-colors';
+    btn.type = 'button';
+    btn.textContent = prompt;
+    host.appendChild(btn);
+  }
+}
 
 function injectCodeBlockUI(container) {
   for (const pre of container.querySelectorAll('pre')) {
@@ -44,6 +68,7 @@ export function setStreamMode(active) {
 function syncMessageVisibility() {
   const list = $('msgs-list');
   const empty = $('empty-state');
+  renderStarterPrompts();
 
   if (S.messages.length === 0) {
     empty.classList.remove('hidden');
@@ -192,9 +217,16 @@ export function buildMsgEl(msg, showRegen = false) {
 
   const row = el('div', 'flex items-start gap-3');
   const avatar = el('div', 'assistant-avatar-surface w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5');
-  const avatarIcon = svgIcon('M13 10V3L4 14h7v7l9-11h-7z');
-  avatarIcon.classList.add('text-zinc-400');
-  avatar.appendChild(avatarIcon);
+  const agent = S.conversationAgent;
+  if (agent?.icon?.value) {
+    avatar.classList.add('text-sm');
+    avatar.textContent = agent.icon.value;
+    avatar.title = agent.name || 'Assistant';
+  } else {
+    const avatarIcon = svgIcon('M13 10V3L4 14h7v7l9-11h-7z');
+    avatarIcon.classList.add('text-zinc-400');
+    avatar.appendChild(avatarIcon);
+  }
 
   const main = el('div', 'flex-1 min-w-0');
   const bubble = el('div', 'assistant-bubble-surface rounded-2xl rounded-tl-sm px-4 py-3');


### PR DESCRIPTION
## Summary

Made the active agent affect the chat experience in a visible, advisory way.

Starter prompts now come from the active conversation agent, assistant rows can show the agent icon, and the request path now carries the agent's temperature and max-token defaults when present.

Closes #195

---

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test-only change
- [ ] Documentation update
- [ ] Build / CI / tooling change
- [ ] Other: None

---

## What Changed

- Updated `freeforge/src/ui/messages.js` to render starter prompts from the active conversation agent and to show the agent icon in assistant message rows.
- Updated `freeforge/src/agent-runtime.js` to build request parameters from optional agent temperature and max-token defaults.
- Updated `freeforge/src/features/chat.js` to send those parameters with each completion request.
- Updated `freeforge/src/features/models.js` so an agent's preferred model can be selected when no explicit user choice already exists.
- Updated `freeforge/src/ui/agent-builder.js` to make the optional model-default fields read as optional in the shell.
- Updated `freeforge/index.html` to give the starter-prompt container a stable target for dynamic rendering.

---

## Why This Approach

These defaults are advisory, so the chat flow keeps user model choice authoritative while still letting an agent shape the starting experience.

Keeping the prompt chips and runtime parameters separate avoids mixing UI convenience with request composition.

---

## Testing

### Commands Run

```bash
node --check freeforge/src/agent-runtime.js
node --check freeforge/src/features/chat.js
node --check freeforge/src/features/models.js
node --check freeforge/src/ui/messages.js
node --check freeforge/src/ui/agent-builder.js
node --check freeforge/src/features/agents.js
node --check freeforge/src/app.js
```

### Results

- Syntax checks passed for the runtime, chat, model, messages, builder, controller, and app modules.
- Behavior check passed for request parameter generation and duplicate-ID import regeneration.

### Coverage Added or Updated

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing only
- [ ] Not applicable — explain why: None

---

## Screenshots / Logs / Evidence

- Behavior check output: `behavior-check-ok`
- No screenshot needed; this is mostly runtime and empty-state rendering logic.

---

## Risk Assessment

### Risk Level

- [ ] Low
- [x] Medium
- [ ] High

### Possible Impact

The request payload now includes agent-derived model parameters, so a bad value would show up as a completion error rather than a UI failure.

### Rollback Plan

Revert commit `20f14e7` on the issue-195 branch or back out the new request-parameter path if the defaults need to be simplified.

---

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes included

Details:

None.

---

## Reviewer Focus

Please pay special attention to:

- Keeping agent defaults advisory rather than mandatory
- Whether the starter prompts disappear and re-render correctly across chat resets
- Whether the assistant avatar fallback still looks acceptable when no agent icon is set

---

## Checklist

- [x] PR is linked to the correct issue
- [x] Tests pass locally
- [ ] Relevant tests were added or updated
- [x] Only files relevant to this issue were modified
- [x] No secrets, credentials, API keys, or environment-specific values introduced
- [x] Error handling was considered
- [x] Edge cases were considered
- [ ] Documentation updated, or not needed
- [x] No breaking changes, or they are clearly documented above
- [ ] This PR is ready for review

---

## Notes for Follow-Up Work

Need #196 to lock in the schema, storage, and request-composition behavior with tests.
