### PR TITLE
test(security): add coverage for exportConversation()

### DIFF
--- a/tests/security/export.test.mjs
+++ b/tests/security/export.test.mjs
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { S } from '../../freeforge/src/state.js';
+import { importFresh, installGlobals, makeBaseDom, makeWindow } from '../helpers/mock-dom.mjs';
+
+async function loadExportModule({ onCreateObjectURL, onRevokeObjectURL } = {}) {
+  const doc = makeBaseDom();
+  const restore = installGlobals({
+    document: doc,
+    window: makeWindow(),
+    URL: {
+      createObjectURL(blob) {
+        if (onCreateObjectURL) return onCreateObjectURL(blob);
+        return 'blob:fake-url';
+      },
+      revokeObjectURL(url) {
+        if (onRevokeObjectURL) onRevokeObjectURL(url);
+      },
+    },
+  });
+  const mod = await importFresh('freeforge/src/features/export.js');
+  return { doc, mod, restore };
+}
+
+test('exportConversation shows info toast when there is nothing to export', async () => {
+  const { doc, mod, restore } = await loadExportModule({
+    onCreateObjectURL() {
+      throw new Error('createObjectURL should not be called');
+    },
+  });
+
+  try {
+    S.messages = [];
+    mod.exportConversation();
+
+    const toasts = doc.getElementById('toasts');
+    const msg = toasts.children[0]?.querySelector('span');
+    assert.equal(toasts.children.length, 1);
+    assert.match(msg?.textContent ?? '', /No conversation to export yet/);
+  } finally {
+    restore();
+  }
+});
+
+test('exportConversation excludes notice messages from exported markdown', async () => {
+  let capturedBlob = null;
+  const { mod, restore } = await loadExportModule({
+    onCreateObjectURL(blob) {
+      capturedBlob = blob;
+      return 'blob:fake-url';
+    },
+  });
+
+  try {
+    S.messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'notice', content: 'ignored' },
+      { role: 'assistant', content: 'World' },
+    ];
+
+    mod.exportConversation();
+
+    assert.ok(capturedBlob);
+    const text = await capturedBlob.text();
+    assert.equal(text, '## user\n\nHello\n\n---\n\n## assistant\n\nWorld');
+    assert.doesNotMatch(text, /ignored/);
+  } finally {
+    restore();
+  }
+});
+
+test('exportConversation formats messages with markdown separators', async () => {
+  let capturedBlob = null;
+  const { mod, restore } = await loadExportModule({
+    onCreateObjectURL(blob) {
+      capturedBlob = blob;
+      return 'blob:fake-url';
+    },
+  });
+
+  try {
+    S.messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'World' },
+    ];
+
+    mod.exportConversation();
+
+    assert.ok(capturedBlob);
+    const text = await capturedBlob.text();
+    assert.equal(text, '## user\n\nHello\n\n---\n\n## assistant\n\nWorld');
+  } finally {
+    restore();
+  }
+});
+
+test('exportConversation revokes the created object URL after the anchor click', async () => {
+  let capturedBlob = null;
+  const revoked = [];
+  const { doc, mod, restore } = await loadExportModule({
+    onCreateObjectURL(blob) {
+      capturedBlob = blob;
+      return 'blob:fake-url';
+    },
+    onRevokeObjectURL(url) {
+      revoked.push(url);
+    },
+  });
+
+  const originalCreateElement = doc.createElement.bind(doc);
+  let clickCount = 0;
+  doc.createElement = tag => {
+    const el = originalCreateElement(tag);
+    if (tag === 'a') el.click = () => { clickCount += 1; };
+    return el;
+  };
+
+  try {
+    S.messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'World' },
+    ];
+
+    mod.exportConversation();
+
+    assert.ok(capturedBlob);
+    assert.equal(clickCount, 1);
+    assert.deepEqual(revoked, ['blob:fake-url']);
+  } finally {
+    restore();
+  }
+});
+
+test('exportConversation shows a success toast after exporting', async () => {
+  const { doc, mod, restore } = await loadExportModule({
+    onCreateObjectURL() {
+      return 'blob:fake-url';
+    },
+  });
+
+  try {
+    S.messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'World' },
+    ];
+
+    mod.exportConversation();
+
+    const toasts = doc.getElementById('toasts');
+    const msg = toasts.children[0]?.querySelector('span');
+    assert.equal(toasts.children.length, 1);
+    assert.match(msg?.textContent ?? '', /Conversation exported/);
+  } finally {
+    restore();
+  }
+});


### PR DESCRIPTION
## Summary

Added focused coverage for `exportConversation()` so its filtering, markdown formatting, URL cleanup, and toast behavior are exercised by the security test suite.

This closes the gap on the only source file without test coverage in the export path.

Closes #207

---

## Type of Change

- [x] Test-only change

---

## What Changed

- Added `tests/security/export.test.mjs` with five tests covering empty exports, filtering out notice messages, markdown formatting, object URL revocation, and the success toast.

---

## Why This Approach

`exportConversation()` is small enough to cover directly with a DOM mock and a lightweight `URL` stub, which makes regressions in the exported text and cleanup behavior visible without adding runtime dependencies.

---

## Testing

### Commands Run

```bash
node --test tests/security/export.test.mjs
npx --yes @biomejs/biome@1.9.4 check tests/security/export.test.mjs
```

### Results

- `node --test tests/security/export.test.mjs`: pass 5, fail 0
- `npx --yes @biomejs/biome@1.9.4 check tests/security/export.test.mjs`: exit 0

### Coverage Added or Updated

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual testing only
- [ ] Not applicable — explain why: N/A

---

## Screenshots / Logs / Evidence

Focused export coverage completed with 5 passing subtests.

---

## Risk Assessment

### Risk Level

- [x] Low

### Possible Impact

No production behavior changed; this only adds regression coverage around an existing feature.

### Rollback Plan

Remove `tests/security/export.test.mjs` if the export path changes substantially in a later refactor.

---

## Breaking Changes

- [x] No breaking changes

Details:

None.

---

## Reviewer Focus

Please pay special attention to:

- Whether the DOM mock assertions reflect the actual toast rendering path
- Whether the exported markdown format exactly matches the runtime implementation
- Whether any additional edge cases should be covered in a follow-up test file

---

## Checklist

- [x] PR is linked to the correct issue
- [x] Tests pass locally
- [x] Relevant tests were added or updated
- [x] Only files relevant to this issue were modified
- [x] No secrets, credentials, API keys, or environment-specific values introduced
- [x] Error handling was considered
- [x] Edge cases were considered
- [ ] Documentation updated, or not needed
- [x] No breaking changes, or they are clearly documented above
- [x] This PR is ready for review

---

## Notes for Follow-Up Work

None.
